### PR TITLE
Rename jupyterlab_bokeh -> jupyter_bokeh

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/bokeh/jupyterlab_bokeh.git"
+    "url": "https://github.com/bokeh/jupyter_bokeh.git"
   },
   "dependencies": {
     "@jupyterlab/application": "^1.1.3",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup_args = dict(
     author="Bokeh Team",
     author_email="info@bokeh.org",
     license="BSD-3-Clause",
-    url="https://github.com/bokeh/jupyterlab_bokeh",
+    url="https://github.com/bokeh/jupyter_bokeh",
     packages=find_packages(),
     classifiers=[
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
Note that after rename the old URLs (e.g. remotes) will still work and redirect to the new ones.

fixes #72 