### PR TITLE
Support JupyterLab 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: generic
-sudo: false
-dist: trusty
+dist: bionic
 cache:
   directories:
     - $HOME/.npm
@@ -15,7 +14,7 @@ install:
 - conda config --add channels bokeh
 - conda config --add channels conda-forge
 - conda info -a
-- conda install conda-build nodejs selenium jupyterlab notebook geckodriver firefox
+- conda install conda-build nodejs jupyterlab notebook
 - npm set progress false
 - npm install -g npm
 - conda build conda.recipe/
@@ -26,4 +25,4 @@ script:
 - jupyter labextension install .
 - jupyter lab clean
 - jupyter labextension link .
-- python -m jupyterlab.selenium_check
+- python -m jupyterlab.browser_check

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bokeh/jupyter_bokeh",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25,59 +25,85 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
-      "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+      "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
     },
     "@blueprintjs/core": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.19.1.tgz",
-      "integrity": "sha512-O+p/Jbu9kyrTE4Yy5phd7Xp9NJoiHCQ9ycO+QSR2fiuhwnVMO1xjY269QXxylzEswgPyjhST1euqHpyQQ7qnUw==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.24.0.tgz",
+      "integrity": "sha512-qW29DDPjzYsT27J6n97C0jZ1ifvEEziwNC98UhaKdSE7I8qxbLsb+ft2JOop+pEX4ab67T1lhQKAiQjWCPKZng==",
       "requires": {
-        "@blueprintjs/icons": "^3.11.0",
+        "@blueprintjs/icons": "^3.14.0",
         "@types/dom4": "^2.0.1",
         "classnames": "^2.2",
         "dom4": "^2.1.5",
         "normalize.css": "^8.0.1",
         "popper.js": "^1.15.0",
         "react-lifecycles-compat": "^3.0.4",
-        "react-popper": "^1.3.3",
+        "react-popper": "^1.3.7",
         "react-transition-group": "^2.9.0",
         "resize-observer-polyfill": "^1.5.1",
-        "tslib": "~1.9.0"
+        "tslib": "~1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
       }
     },
     "@blueprintjs/icons": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.11.0.tgz",
-      "integrity": "sha512-HGS652gFc057t9cr8NyuWFyZ1gcSqG3uuexpzhZm81W35hGfh9vdC9GR+mbHJNawAuKXtu+xw4VWWkv1UGQ0Vg==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.14.0.tgz",
+      "integrity": "sha512-cvQ3CSdy0DqVqcXcPqSxoycJw497TVP5goyE6xCFlVs84477ahxh7Uung6J+CCoDVBuI87h576LtuyjwSxorvQ==",
       "requires": {
         "classnames": "^2.2",
-        "tslib": "~1.9.0"
+        "tslib": "~1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
       }
     },
     "@blueprintjs/select": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-3.11.1.tgz",
-      "integrity": "sha512-J3IfKq+L9JsKQQbrLdJ9K2621FV2K7iptynklSsCP6owlGDDcsbS6JEu/X2B8n7f5v0bez070+fQTa2JxtKRFg==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-3.12.0.tgz",
+      "integrity": "sha512-rABlv5M+h7onuoUuNsratyiukPnkdblDm7lt7GT4fbRmJglSsKylNnfHogNDZkMMHqmgmVB05mgzBQ+kcLA1cw==",
       "requires": {
-        "@blueprintjs/core": "^3.19.0",
+        "@blueprintjs/core": "^3.24.0",
         "classnames": "^2.2",
-        "tslib": "~1.9.0"
+        "tslib": "~1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
       }
     },
+    "@fortawesome/fontawesome-free": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.12.1.tgz",
+      "integrity": "sha512-ZtjIIFplxncqxvogq148C3hBLQE+W3iJ8E4UvJ09zIJUgzwLcROsWwFDErVSXY2Plzao5J9KUYNHKHMEUYDMKw=="
+    },
     "@jupyter-widgets/base": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@jupyter-widgets/base/-/base-2.0.1.tgz",
-      "integrity": "sha512-jRNeQzvEf6MMGUaEPfBzgZ+IT4XOInpw8Ef+CunNUmUCiQZ8WfNpFR671S0Vu3xO6yGKMTU2QPdk8/aCsJRw9w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyter-widgets/base/-/base-3.0.0.tgz",
+      "integrity": "sha512-un1ZTHALCwE/SAYk2gEaonYM1JoaFyhosN8a3y2bhl4N26yCB3dP1PqGHLsAFur6ZB7fwuWwBEkIZx+nOwstAQ==",
       "requires": {
-        "@jupyterlab/services": "^4.0.0",
-        "@phosphor/coreutils": "^1.2.0",
-        "@phosphor/messaging": "^1.2.1",
-        "@phosphor/widgets": "^1.3.0",
+        "@jupyterlab/services": "^5.0.0",
+        "@lumino/coreutils": "^1.2.0",
+        "@lumino/messaging": "^1.2.1",
+        "@lumino/widgets": "^1.3.0",
         "@types/backbone": "^1.4.1",
         "@types/lodash": "^4.14.134",
         "backbone": "1.2.3",
@@ -87,1713 +113,524 @@
       }
     },
     "@jupyterlab/application": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-1.1.3.tgz",
-      "integrity": "sha512-iGVIX4LrMApEAZrVhxVSS/o3iEn1QBiiXEdpQ7X8NX9aieWf2xGzvwIrNp1GxX6b3kLzkN4SMFLDAaoZDluMbg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-2.0.0.tgz",
+      "integrity": "sha512-CeN4jwshV/gQqa8dG9R3YlSH2KD3UGsJY+ptGdZqxoq44DNl1xX4gYfNW6VweTJRXPD2uozUywpXu01b1h6KTQ==",
       "requires": {
-        "@jupyterlab/apputils": "^1.1.3",
-        "@jupyterlab/coreutils": "^3.1.0",
-        "@jupyterlab/docregistry": "^1.1.3",
-        "@jupyterlab/rendermime": "^1.1.3",
-        "@jupyterlab/rendermime-interfaces": "^1.4.0",
-        "@jupyterlab/services": "^4.1.1",
-        "@jupyterlab/ui-components": "^1.1.2",
-        "@phosphor/algorithm": "^1.1.3",
-        "@phosphor/application": "^1.6.3",
-        "@phosphor/commands": "^1.6.3",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.2.0",
-        "@phosphor/messaging": "^1.2.3",
-        "@phosphor/properties": "^1.1.3",
-        "@phosphor/signaling": "^1.2.3",
-        "@phosphor/widgets": "^1.8.0",
-        "font-awesome": "~4.7.0"
+        "@fortawesome/fontawesome-free": "^5.12.0",
+        "@jupyterlab/apputils": "^2.0.0",
+        "@jupyterlab/coreutils": "^4.0.0",
+        "@jupyterlab/docregistry": "^2.0.0",
+        "@jupyterlab/rendermime": "^2.0.0",
+        "@jupyterlab/rendermime-interfaces": "^2.0.0",
+        "@jupyterlab/services": "^5.0.0",
+        "@jupyterlab/statedb": "^2.0.0",
+        "@jupyterlab/ui-components": "^2.0.0",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/application": "^1.8.4",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/polling": "^1.0.4",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1"
       }
     },
     "@jupyterlab/apputils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.1.3.tgz",
-      "integrity": "sha512-5kTmNSNedP+Fyhx25gk/yRiMWoEQoqP8u2qnFJslMke+5NJPRTVwi0VW45VZZ9QtnepuT44DJ41Uk7HrQ0TKCA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-2.0.0.tgz",
+      "integrity": "sha512-4dehZZ3XADFbHIWTDxeqxURRCPvC+bDzGmrk8qfBy9kHnvB5A4+X87BobJpnNRjZKx8LxyABddFBQewLfDynkg==",
       "requires": {
-        "@jupyterlab/coreutils": "^3.1.0",
-        "@jupyterlab/services": "^4.1.1",
-        "@jupyterlab/ui-components": "^1.1.2",
-        "@phosphor/algorithm": "^1.1.3",
-        "@phosphor/commands": "^1.6.3",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.2.0",
-        "@phosphor/domutils": "^1.1.3",
-        "@phosphor/messaging": "^1.2.3",
-        "@phosphor/properties": "^1.1.3",
-        "@phosphor/signaling": "^1.2.3",
-        "@phosphor/virtualdom": "^1.1.3",
-        "@phosphor/widgets": "^1.8.0",
-        "@types/react": "~16.8.18",
-        "react": "~16.8.4",
-        "react-dom": "~16.8.4",
+        "@jupyterlab/coreutils": "^4.0.0",
+        "@jupyterlab/services": "^5.0.0",
+        "@jupyterlab/settingregistry": "^2.0.0",
+        "@jupyterlab/statedb": "^2.0.0",
+        "@jupyterlab/ui-components": "^2.0.0",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/domutils": "^1.1.7",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1",
+        "@lumino/widgets": "^1.11.1",
+        "@types/react": "~16.9.16",
+        "react": "~16.9.0",
+        "react-dom": "~16.9.0",
         "sanitize-html": "~1.20.1"
       }
     },
     "@jupyterlab/attachments": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/attachments/-/attachments-1.2.1.tgz",
-      "integrity": "sha512-bbwnzOsRy/abTRcMCKj1eOfop/csIdMQxrecdYLpYPbNtVfjTx3QMEGdTKJArHRBCiSoPXGsw2dIDsGY0hwOYQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/attachments/-/attachments-2.0.0.tgz",
+      "integrity": "sha512-NczM6NBDXOnRr17cuxVy4J0sD5cSb0AsGbTCIxIb32ZiYqqKMgI/Q9TkxjEC1A/713KH6kn3A526KOqCxcaF1Q==",
       "requires": {
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/observables": "^2.4.0",
-        "@jupyterlab/rendermime": "^1.2.1",
-        "@jupyterlab/rendermime-interfaces": "^1.5.0",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/signaling": "^1.3.0"
-      },
-      "dependencies": {
-        "@jupyterlab/apputils": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.2.1.tgz",
-          "integrity": "sha512-xp4GBpMJrK8DTLQmZr0cXwUJElbAbRRtNTxHempigmCEQhzaC1OUN+0M+xOc4Z45Ir0XgcefdCzdwyEUFx1UyQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@jupyterlab/ui-components": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/domutils": "^1.1.3",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "@types/react": "~16.8.18",
-            "react": "~16.8.4",
-            "react-dom": "~16.8.4",
-            "sanitize-html": "~1.20.1"
-          }
-        },
-        "@jupyterlab/codeeditor": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-1.2.0.tgz",
-          "integrity": "sha512-toejhF/a80X10SZyvEnsnnlS9SxR5W4cz67ju7e/2lsZ8RMwZEDDJAJXyW3mw/EEjt8oVRNP2QpM8L5clE9XyQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/dragdrop": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/codemirror": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-1.2.1.tgz",
-          "integrity": "sha512-OtDe4BP9cn9OwY9xsk6foqf+qhnYBtuLIzjoUVbqS4IaHck7gTOA2T2AYBcAFQe9Aj0e/Bb5fo9jBhkVtiFHcA==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codeeditor": "^1.2.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@jupyterlab/statusbar": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "codemirror": "~5.47.0",
-            "react": "~16.8.4"
-          }
-        },
-        "@jupyterlab/coreutils": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.2.0.tgz",
-          "integrity": "sha512-LATiUsHuwze/h3JC2EZOBV+kGBoUKO3npqw/Pcgge4bz09xF/oTDrx4G8jl5eew3w1dCUNp9eLduNh8Orrw7xQ==",
-          "requires": {
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "ajv": "^6.5.5",
-            "json5": "^2.1.0",
-            "minimist": "~1.2.0",
-            "moment": "^2.24.0",
-            "path-posix": "~1.0.0",
-            "url-parse": "~1.4.3"
-          }
-        },
-        "@jupyterlab/observables": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.4.0.tgz",
-          "integrity": "sha512-M/fhAnPqd6F4Zwt4IIsvHCkJmwbSw1Tko/hUXgdUQG86lPsJiTOh98sB3qwV1gtzb9oFF+kH21XsHnQZ6Yl6Pw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0"
-          }
-        },
-        "@jupyterlab/rendermime": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-1.2.1.tgz",
-          "integrity": "sha512-S57dOCQRXoGpUl9bGryAgAcLlDbXBk+Y8HPR2oO95slgk45vVktWl+6f/euNQcjOCX+RkuQuLLsBYeWzCZKCRw==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codemirror": "^1.2.1",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@jupyterlab/rendermime-interfaces": "^1.5.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "lodash.escape": "^4.0.1",
-            "marked": "^0.7.0"
-          }
-        },
-        "@jupyterlab/rendermime-interfaces": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.5.0.tgz",
-          "integrity": "sha512-k6DjX/srKl1FA1CZyrAzz1qA2v1arXUIAmbEddZ5L3O+dnvDlOKjkI/NexaRQvmQ62aziSln+wKrr2P1JPNmGg==",
-          "requires": {
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/services": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.2.0.tgz",
-          "integrity": "sha512-diqiWCYLROwZoeZ46hO4oCINQKr3S789GOA3drw5gDie18/u1nJcvegnY9Oo58xHINnKTs0rKZmFgTe2DvYgQg==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "node-fetch": "^2.6.0",
-            "ws": "^7.0.0"
-          }
-        },
-        "@jupyterlab/statusbar": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-1.2.1.tgz",
-          "integrity": "sha512-T+wmFQwW4tRHDDlY8A6i46G4HE7MP4EXMxcaNnYmPb+HElTgSx9KSrJ4cGRhFNdh5y0PcWwCD4wFUH5qAkEFYg==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codeeditor": "^1.2.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@jupyterlab/ui-components": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "react": "~16.8.4",
-            "typestyle": "^2.0.1"
-          }
-        },
-        "@jupyterlab/ui-components": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.2.1.tgz",
-          "integrity": "sha512-GUtIRwTmFnlJaPUM8SiFw1STmsyMVGjchLKqIoQnn0qYAJvaSUGyRqqoSD5iIpwov6OHCOOyxH6fQ5OAtH1kwA==",
-          "requires": {
-            "@blueprintjs/core": "^3.9.0",
-            "@blueprintjs/select": "^3.3.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "react": "~16.8.4",
-            "typestyle": "^2.0.1"
-          }
-        },
-        "marked": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
-        }
+        "@jupyterlab/nbformat": "^2.0.0",
+        "@jupyterlab/observables": "^3.0.0",
+        "@jupyterlab/rendermime": "^2.0.0",
+        "@jupyterlab/rendermime-interfaces": "^2.0.0",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/signaling": "^1.3.5"
       }
     },
     "@jupyterlab/cells": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/cells/-/cells-1.2.2.tgz",
-      "integrity": "sha512-/DrBgJ/Ik9mtccAO4l4ArVlJ2zXt37zQ/Kxpby4RH3L7xf17cg5uWr4UvExliAGNcMp8gfr4PRFZFPdzOoTtQA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/cells/-/cells-2.0.0.tgz",
+      "integrity": "sha512-7AfcuaUhhX+84qnAySy8nGHmUKUvecyA3cLk60Ctqit53wjTKip10qE/6vObVQgmal0isaKUuQ5XldQA/F6yBw==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/attachments": "^1.2.1",
-        "@jupyterlab/codeeditor": "^1.2.0",
-        "@jupyterlab/codemirror": "^1.2.1",
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/filebrowser": "^1.2.1",
-        "@jupyterlab/observables": "^2.4.0",
-        "@jupyterlab/outputarea": "^1.2.2",
-        "@jupyterlab/rendermime": "^1.2.1",
-        "@jupyterlab/services": "^4.2.0",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/dragdrop": "^1.3.0",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/virtualdom": "^1.2.0",
-        "@phosphor/widgets": "^1.9.0",
-        "react": "~16.8.4"
-      },
-      "dependencies": {
-        "@jupyterlab/apputils": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.2.1.tgz",
-          "integrity": "sha512-xp4GBpMJrK8DTLQmZr0cXwUJElbAbRRtNTxHempigmCEQhzaC1OUN+0M+xOc4Z45Ir0XgcefdCzdwyEUFx1UyQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@jupyterlab/ui-components": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/domutils": "^1.1.3",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "@types/react": "~16.8.18",
-            "react": "~16.8.4",
-            "react-dom": "~16.8.4",
-            "sanitize-html": "~1.20.1"
-          }
-        },
-        "@jupyterlab/codeeditor": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-1.2.0.tgz",
-          "integrity": "sha512-toejhF/a80X10SZyvEnsnnlS9SxR5W4cz67ju7e/2lsZ8RMwZEDDJAJXyW3mw/EEjt8oVRNP2QpM8L5clE9XyQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/dragdrop": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/codemirror": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-1.2.1.tgz",
-          "integrity": "sha512-OtDe4BP9cn9OwY9xsk6foqf+qhnYBtuLIzjoUVbqS4IaHck7gTOA2T2AYBcAFQe9Aj0e/Bb5fo9jBhkVtiFHcA==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codeeditor": "^1.2.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@jupyterlab/statusbar": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "codemirror": "~5.47.0",
-            "react": "~16.8.4"
-          }
-        },
-        "@jupyterlab/coreutils": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.2.0.tgz",
-          "integrity": "sha512-LATiUsHuwze/h3JC2EZOBV+kGBoUKO3npqw/Pcgge4bz09xF/oTDrx4G8jl5eew3w1dCUNp9eLduNh8Orrw7xQ==",
-          "requires": {
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "ajv": "^6.5.5",
-            "json5": "^2.1.0",
-            "minimist": "~1.2.0",
-            "moment": "^2.24.0",
-            "path-posix": "~1.0.0",
-            "url-parse": "~1.4.3"
-          }
-        },
-        "@jupyterlab/observables": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.4.0.tgz",
-          "integrity": "sha512-M/fhAnPqd6F4Zwt4IIsvHCkJmwbSw1Tko/hUXgdUQG86lPsJiTOh98sB3qwV1gtzb9oFF+kH21XsHnQZ6Yl6Pw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0"
-          }
-        },
-        "@jupyterlab/rendermime": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-1.2.1.tgz",
-          "integrity": "sha512-S57dOCQRXoGpUl9bGryAgAcLlDbXBk+Y8HPR2oO95slgk45vVktWl+6f/euNQcjOCX+RkuQuLLsBYeWzCZKCRw==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codemirror": "^1.2.1",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@jupyterlab/rendermime-interfaces": "^1.5.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "lodash.escape": "^4.0.1",
-            "marked": "^0.7.0"
-          }
-        },
-        "@jupyterlab/rendermime-interfaces": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.5.0.tgz",
-          "integrity": "sha512-k6DjX/srKl1FA1CZyrAzz1qA2v1arXUIAmbEddZ5L3O+dnvDlOKjkI/NexaRQvmQ62aziSln+wKrr2P1JPNmGg==",
-          "requires": {
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/services": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.2.0.tgz",
-          "integrity": "sha512-diqiWCYLROwZoeZ46hO4oCINQKr3S789GOA3drw5gDie18/u1nJcvegnY9Oo58xHINnKTs0rKZmFgTe2DvYgQg==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "node-fetch": "^2.6.0",
-            "ws": "^7.0.0"
-          }
-        },
-        "@jupyterlab/statusbar": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-1.2.1.tgz",
-          "integrity": "sha512-T+wmFQwW4tRHDDlY8A6i46G4HE7MP4EXMxcaNnYmPb+HElTgSx9KSrJ4cGRhFNdh5y0PcWwCD4wFUH5qAkEFYg==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codeeditor": "^1.2.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@jupyterlab/ui-components": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "react": "~16.8.4",
-            "typestyle": "^2.0.1"
-          }
-        },
-        "@jupyterlab/ui-components": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.2.1.tgz",
-          "integrity": "sha512-GUtIRwTmFnlJaPUM8SiFw1STmsyMVGjchLKqIoQnn0qYAJvaSUGyRqqoSD5iIpwov6OHCOOyxH6fQ5OAtH1kwA==",
-          "requires": {
-            "@blueprintjs/core": "^3.9.0",
-            "@blueprintjs/select": "^3.3.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "react": "~16.8.4",
-            "typestyle": "^2.0.1"
-          }
-        },
-        "marked": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
-        }
+        "@jupyterlab/apputils": "^2.0.0",
+        "@jupyterlab/attachments": "^2.0.0",
+        "@jupyterlab/codeeditor": "^2.0.0",
+        "@jupyterlab/codemirror": "^2.0.0",
+        "@jupyterlab/coreutils": "^4.0.0",
+        "@jupyterlab/filebrowser": "^2.0.0",
+        "@jupyterlab/nbformat": "^2.0.0",
+        "@jupyterlab/observables": "^3.0.0",
+        "@jupyterlab/outputarea": "^2.0.0",
+        "@jupyterlab/rendermime": "^2.0.0",
+        "@jupyterlab/services": "^5.0.0",
+        "@jupyterlab/ui-components": "^2.0.0",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/dragdrop": "^1.5.1",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1",
+        "@lumino/widgets": "^1.11.1",
+        "react": "~16.9.0"
       }
     },
     "@jupyterlab/codeeditor": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-1.1.0.tgz",
-      "integrity": "sha512-G22xSQajqJV0UxtaEkpRDsGAqumtkkpyjtN0yoqD/wlGentAllk1D1Sup99MBQKfZN+sBERbuUdLd0Oz5Q0e3g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-2.0.0.tgz",
+      "integrity": "sha512-4aqupSmOFRdmUOZxv3xxRoXAQK6oEdTjyMNFe2N/gXVdWZOBfAezSt1c8sN4xrVG3BkUDmzaRHAXhgTWNp8LHw==",
       "requires": {
-        "@jupyterlab/coreutils": "^3.1.0",
-        "@jupyterlab/observables": "^2.3.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.2.0",
-        "@phosphor/dragdrop": "^1.3.3",
-        "@phosphor/messaging": "^1.2.3",
-        "@phosphor/signaling": "^1.2.3",
-        "@phosphor/widgets": "^1.8.0"
+        "@jupyterlab/coreutils": "^4.0.0",
+        "@jupyterlab/nbformat": "^2.0.0",
+        "@jupyterlab/observables": "^3.0.0",
+        "@jupyterlab/ui-components": "^2.0.0",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/dragdrop": "^1.5.1",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1"
       }
     },
     "@jupyterlab/codemirror": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-1.2.1.tgz",
-      "integrity": "sha512-OtDe4BP9cn9OwY9xsk6foqf+qhnYBtuLIzjoUVbqS4IaHck7gTOA2T2AYBcAFQe9Aj0e/Bb5fo9jBhkVtiFHcA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-2.0.0.tgz",
+      "integrity": "sha512-6BbdS5tCKhxVc9GtkVQuE5bxuJDZD2kTVUlLHaO7UsRWpU9PHkVEn8D0PmA8ilZw3DmVN/xsSCwGkTuT0CTKMQ==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/codeeditor": "^1.2.0",
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/observables": "^2.4.0",
-        "@jupyterlab/statusbar": "^1.2.1",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/commands": "^1.7.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/widgets": "^1.9.0",
-        "codemirror": "~5.47.0",
-        "react": "~16.8.4"
-      },
-      "dependencies": {
-        "@jupyterlab/apputils": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.2.1.tgz",
-          "integrity": "sha512-xp4GBpMJrK8DTLQmZr0cXwUJElbAbRRtNTxHempigmCEQhzaC1OUN+0M+xOc4Z45Ir0XgcefdCzdwyEUFx1UyQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@jupyterlab/ui-components": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/domutils": "^1.1.3",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "@types/react": "~16.8.18",
-            "react": "~16.8.4",
-            "react-dom": "~16.8.4",
-            "sanitize-html": "~1.20.1"
-          }
-        },
-        "@jupyterlab/codeeditor": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-1.2.0.tgz",
-          "integrity": "sha512-toejhF/a80X10SZyvEnsnnlS9SxR5W4cz67ju7e/2lsZ8RMwZEDDJAJXyW3mw/EEjt8oVRNP2QpM8L5clE9XyQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/dragdrop": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/coreutils": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.2.0.tgz",
-          "integrity": "sha512-LATiUsHuwze/h3JC2EZOBV+kGBoUKO3npqw/Pcgge4bz09xF/oTDrx4G8jl5eew3w1dCUNp9eLduNh8Orrw7xQ==",
-          "requires": {
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "ajv": "^6.5.5",
-            "json5": "^2.1.0",
-            "minimist": "~1.2.0",
-            "moment": "^2.24.0",
-            "path-posix": "~1.0.0",
-            "url-parse": "~1.4.3"
-          }
-        },
-        "@jupyterlab/observables": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.4.0.tgz",
-          "integrity": "sha512-M/fhAnPqd6F4Zwt4IIsvHCkJmwbSw1Tko/hUXgdUQG86lPsJiTOh98sB3qwV1gtzb9oFF+kH21XsHnQZ6Yl6Pw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0"
-          }
-        },
-        "@jupyterlab/services": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.2.0.tgz",
-          "integrity": "sha512-diqiWCYLROwZoeZ46hO4oCINQKr3S789GOA3drw5gDie18/u1nJcvegnY9Oo58xHINnKTs0rKZmFgTe2DvYgQg==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "node-fetch": "^2.6.0",
-            "ws": "^7.0.0"
-          }
-        },
-        "@jupyterlab/statusbar": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-1.2.1.tgz",
-          "integrity": "sha512-T+wmFQwW4tRHDDlY8A6i46G4HE7MP4EXMxcaNnYmPb+HElTgSx9KSrJ4cGRhFNdh5y0PcWwCD4wFUH5qAkEFYg==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codeeditor": "^1.2.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@jupyterlab/ui-components": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "react": "~16.8.4",
-            "typestyle": "^2.0.1"
-          }
-        },
-        "@jupyterlab/ui-components": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.2.1.tgz",
-          "integrity": "sha512-GUtIRwTmFnlJaPUM8SiFw1STmsyMVGjchLKqIoQnn0qYAJvaSUGyRqqoSD5iIpwov6OHCOOyxH6fQ5OAtH1kwA==",
-          "requires": {
-            "@blueprintjs/core": "^3.9.0",
-            "@blueprintjs/select": "^3.3.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "react": "~16.8.4",
-            "typestyle": "^2.0.1"
-          }
-        }
+        "@jupyterlab/apputils": "^2.0.0",
+        "@jupyterlab/codeeditor": "^2.0.0",
+        "@jupyterlab/coreutils": "^4.0.0",
+        "@jupyterlab/nbformat": "^2.0.0",
+        "@jupyterlab/observables": "^3.0.0",
+        "@jupyterlab/statusbar": "^2.0.0",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/polling": "^1.0.4",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1",
+        "codemirror": "~5.49.2",
+        "react": "~16.9.0"
       }
     },
     "@jupyterlab/coreutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.1.0.tgz",
-      "integrity": "sha512-ZqgzDUyanyvc86gtCrIbc1M6iniKHYmWNWHvWOcnq3KIP3wk3grchsTYPTfQDxcUS6F04baPGp/KohEU2ml40Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-4.0.0.tgz",
+      "integrity": "sha512-f7wvlmJSYiSsjzTjD2wI6iXbt8hPYjWlM0l7J2ULbI7E1tsPmpn14mo/kmF/Ft0cLYXP9ApkItU5QrXB5BNoXA==",
       "requires": {
-        "@phosphor/commands": "^1.6.3",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.2.0",
-        "@phosphor/properties": "^1.1.3",
-        "@phosphor/signaling": "^1.2.3",
-        "ajv": "^6.5.5",
-        "json5": "^2.1.0",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/signaling": "^1.3.5",
         "minimist": "~1.2.0",
         "moment": "^2.24.0",
         "path-posix": "~1.0.0",
-        "url-parse": "~1.4.3"
+        "url-parse": "~1.4.7"
       }
     },
     "@jupyterlab/docmanager": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/docmanager/-/docmanager-1.2.1.tgz",
-      "integrity": "sha512-4XyXMqx6oxxXW28p/dWX0S5BYwY3RiSKCzN8XuSTfre85jsNQz2712ZyJ51WeevIJ7U+6T/CRRILEv8Jo5SNbg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/docmanager/-/docmanager-2.0.0.tgz",
+      "integrity": "sha512-r8qYuatNOn0wI5DVxvxOrZSm7+XNpb1MaWtL4nHhyRSUkxFjIapMcbZMYTFa8b9W2CI9gKFRGvL1WS+l0SvWoQ==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/docregistry": "^1.2.1",
-        "@jupyterlab/services": "^4.2.0",
-        "@jupyterlab/statusbar": "^1.2.1",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/properties": "^1.1.3",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/widgets": "^1.9.0",
-        "react": "~16.8.4"
-      },
-      "dependencies": {
-        "@jupyterlab/apputils": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.2.1.tgz",
-          "integrity": "sha512-xp4GBpMJrK8DTLQmZr0cXwUJElbAbRRtNTxHempigmCEQhzaC1OUN+0M+xOc4Z45Ir0XgcefdCzdwyEUFx1UyQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@jupyterlab/ui-components": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/domutils": "^1.1.3",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "@types/react": "~16.8.18",
-            "react": "~16.8.4",
-            "react-dom": "~16.8.4",
-            "sanitize-html": "~1.20.1"
-          }
-        },
-        "@jupyterlab/codeeditor": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-1.2.0.tgz",
-          "integrity": "sha512-toejhF/a80X10SZyvEnsnnlS9SxR5W4cz67ju7e/2lsZ8RMwZEDDJAJXyW3mw/EEjt8oVRNP2QpM8L5clE9XyQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/dragdrop": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/codemirror": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-1.2.1.tgz",
-          "integrity": "sha512-OtDe4BP9cn9OwY9xsk6foqf+qhnYBtuLIzjoUVbqS4IaHck7gTOA2T2AYBcAFQe9Aj0e/Bb5fo9jBhkVtiFHcA==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codeeditor": "^1.2.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@jupyterlab/statusbar": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "codemirror": "~5.47.0",
-            "react": "~16.8.4"
-          }
-        },
-        "@jupyterlab/coreutils": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.2.0.tgz",
-          "integrity": "sha512-LATiUsHuwze/h3JC2EZOBV+kGBoUKO3npqw/Pcgge4bz09xF/oTDrx4G8jl5eew3w1dCUNp9eLduNh8Orrw7xQ==",
-          "requires": {
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "ajv": "^6.5.5",
-            "json5": "^2.1.0",
-            "minimist": "~1.2.0",
-            "moment": "^2.24.0",
-            "path-posix": "~1.0.0",
-            "url-parse": "~1.4.3"
-          }
-        },
-        "@jupyterlab/docregistry": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-1.2.1.tgz",
-          "integrity": "sha512-EUj0c6VKB5YD7RrH/b4xyJLExNsgKNjysegLLN9dFGamz4azfylOJlbxqyN1n1GeLIG4rGsGT1pD7qzDlTQGEA==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codeeditor": "^1.2.0",
-            "@jupyterlab/codemirror": "^1.2.1",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@jupyterlab/rendermime": "^1.2.1",
-            "@jupyterlab/rendermime-interfaces": "^1.5.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/observables": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.4.0.tgz",
-          "integrity": "sha512-M/fhAnPqd6F4Zwt4IIsvHCkJmwbSw1Tko/hUXgdUQG86lPsJiTOh98sB3qwV1gtzb9oFF+kH21XsHnQZ6Yl6Pw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0"
-          }
-        },
-        "@jupyterlab/rendermime": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-1.2.1.tgz",
-          "integrity": "sha512-S57dOCQRXoGpUl9bGryAgAcLlDbXBk+Y8HPR2oO95slgk45vVktWl+6f/euNQcjOCX+RkuQuLLsBYeWzCZKCRw==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codemirror": "^1.2.1",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@jupyterlab/rendermime-interfaces": "^1.5.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "lodash.escape": "^4.0.1",
-            "marked": "^0.7.0"
-          }
-        },
-        "@jupyterlab/rendermime-interfaces": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.5.0.tgz",
-          "integrity": "sha512-k6DjX/srKl1FA1CZyrAzz1qA2v1arXUIAmbEddZ5L3O+dnvDlOKjkI/NexaRQvmQ62aziSln+wKrr2P1JPNmGg==",
-          "requires": {
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/services": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.2.0.tgz",
-          "integrity": "sha512-diqiWCYLROwZoeZ46hO4oCINQKr3S789GOA3drw5gDie18/u1nJcvegnY9Oo58xHINnKTs0rKZmFgTe2DvYgQg==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "node-fetch": "^2.6.0",
-            "ws": "^7.0.0"
-          }
-        },
-        "@jupyterlab/statusbar": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-1.2.1.tgz",
-          "integrity": "sha512-T+wmFQwW4tRHDDlY8A6i46G4HE7MP4EXMxcaNnYmPb+HElTgSx9KSrJ4cGRhFNdh5y0PcWwCD4wFUH5qAkEFYg==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codeeditor": "^1.2.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@jupyterlab/ui-components": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "react": "~16.8.4",
-            "typestyle": "^2.0.1"
-          }
-        },
-        "@jupyterlab/ui-components": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.2.1.tgz",
-          "integrity": "sha512-GUtIRwTmFnlJaPUM8SiFw1STmsyMVGjchLKqIoQnn0qYAJvaSUGyRqqoSD5iIpwov6OHCOOyxH6fQ5OAtH1kwA==",
-          "requires": {
-            "@blueprintjs/core": "^3.9.0",
-            "@blueprintjs/select": "^3.3.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "react": "~16.8.4",
-            "typestyle": "^2.0.1"
-          }
-        },
-        "marked": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
-        }
+        "@jupyterlab/apputils": "^2.0.0",
+        "@jupyterlab/coreutils": "^4.0.0",
+        "@jupyterlab/docregistry": "^2.0.0",
+        "@jupyterlab/services": "^5.0.0",
+        "@jupyterlab/statusbar": "^2.0.0",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1",
+        "react": "~16.9.0"
       }
     },
     "@jupyterlab/docregistry": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-1.2.1.tgz",
-      "integrity": "sha512-EUj0c6VKB5YD7RrH/b4xyJLExNsgKNjysegLLN9dFGamz4azfylOJlbxqyN1n1GeLIG4rGsGT1pD7qzDlTQGEA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-2.0.0.tgz",
+      "integrity": "sha512-JhsSNMv9Mgzc2M9qm3OmTi26qtS7jF/s6WexWx5LBpt0B4uekJoq1ro3B96xInO4Z6XqByuKW4ozRXqrHyea6w==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/codeeditor": "^1.2.0",
-        "@jupyterlab/codemirror": "^1.2.1",
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/observables": "^2.4.0",
-        "@jupyterlab/rendermime": "^1.2.1",
-        "@jupyterlab/rendermime-interfaces": "^1.5.0",
-        "@jupyterlab/services": "^4.2.0",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/widgets": "^1.9.0"
-      },
-      "dependencies": {
-        "@jupyterlab/apputils": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.2.1.tgz",
-          "integrity": "sha512-xp4GBpMJrK8DTLQmZr0cXwUJElbAbRRtNTxHempigmCEQhzaC1OUN+0M+xOc4Z45Ir0XgcefdCzdwyEUFx1UyQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@jupyterlab/ui-components": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/domutils": "^1.1.3",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "@types/react": "~16.8.18",
-            "react": "~16.8.4",
-            "react-dom": "~16.8.4",
-            "sanitize-html": "~1.20.1"
-          }
-        },
-        "@jupyterlab/codeeditor": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-1.2.0.tgz",
-          "integrity": "sha512-toejhF/a80X10SZyvEnsnnlS9SxR5W4cz67ju7e/2lsZ8RMwZEDDJAJXyW3mw/EEjt8oVRNP2QpM8L5clE9XyQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/dragdrop": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/coreutils": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.2.0.tgz",
-          "integrity": "sha512-LATiUsHuwze/h3JC2EZOBV+kGBoUKO3npqw/Pcgge4bz09xF/oTDrx4G8jl5eew3w1dCUNp9eLduNh8Orrw7xQ==",
-          "requires": {
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "ajv": "^6.5.5",
-            "json5": "^2.1.0",
-            "minimist": "~1.2.0",
-            "moment": "^2.24.0",
-            "path-posix": "~1.0.0",
-            "url-parse": "~1.4.3"
-          }
-        },
-        "@jupyterlab/observables": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.4.0.tgz",
-          "integrity": "sha512-M/fhAnPqd6F4Zwt4IIsvHCkJmwbSw1Tko/hUXgdUQG86lPsJiTOh98sB3qwV1gtzb9oFF+kH21XsHnQZ6Yl6Pw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0"
-          }
-        },
-        "@jupyterlab/rendermime-interfaces": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.5.0.tgz",
-          "integrity": "sha512-k6DjX/srKl1FA1CZyrAzz1qA2v1arXUIAmbEddZ5L3O+dnvDlOKjkI/NexaRQvmQ62aziSln+wKrr2P1JPNmGg==",
-          "requires": {
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/services": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.2.0.tgz",
-          "integrity": "sha512-diqiWCYLROwZoeZ46hO4oCINQKr3S789GOA3drw5gDie18/u1nJcvegnY9Oo58xHINnKTs0rKZmFgTe2DvYgQg==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "node-fetch": "^2.6.0",
-            "ws": "^7.0.0"
-          }
-        },
-        "@jupyterlab/ui-components": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.2.1.tgz",
-          "integrity": "sha512-GUtIRwTmFnlJaPUM8SiFw1STmsyMVGjchLKqIoQnn0qYAJvaSUGyRqqoSD5iIpwov6OHCOOyxH6fQ5OAtH1kwA==",
-          "requires": {
-            "@blueprintjs/core": "^3.9.0",
-            "@blueprintjs/select": "^3.3.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "react": "~16.8.4",
-            "typestyle": "^2.0.1"
-          }
-        }
+        "@jupyterlab/apputils": "^2.0.0",
+        "@jupyterlab/codeeditor": "^2.0.0",
+        "@jupyterlab/codemirror": "^2.0.0",
+        "@jupyterlab/coreutils": "^4.0.0",
+        "@jupyterlab/observables": "^3.0.0",
+        "@jupyterlab/rendermime": "^2.0.0",
+        "@jupyterlab/rendermime-interfaces": "^2.0.0",
+        "@jupyterlab/services": "^5.0.0",
+        "@jupyterlab/ui-components": "^2.0.0",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1"
       }
     },
     "@jupyterlab/filebrowser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/filebrowser/-/filebrowser-1.2.1.tgz",
-      "integrity": "sha512-OQS72Pf41npmpt+t5RRRPqhCqO+J1vzTQtFLOq6MvLMTY+xF/sNR8AUSFWr6J05czPYMfnRhhpkHORqYmYwtGQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/filebrowser/-/filebrowser-2.0.0.tgz",
+      "integrity": "sha512-vvG3OE/yY8VAlsyojLv329+rpXzchhmWWWtj77ld5mhKUG8167A4mDHpeiMO71uVGTWSB9FGYnYmKPi//U3Owg==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/docmanager": "^1.2.1",
-        "@jupyterlab/docregistry": "^1.2.1",
-        "@jupyterlab/services": "^4.2.0",
-        "@jupyterlab/statusbar": "^1.2.1",
-        "@jupyterlab/ui-components": "^1.2.1",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/domutils": "^1.1.3",
-        "@phosphor/dragdrop": "^1.3.0",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/widgets": "^1.9.0",
-        "react": "~16.8.4"
-      },
-      "dependencies": {
-        "@jupyterlab/apputils": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.2.1.tgz",
-          "integrity": "sha512-xp4GBpMJrK8DTLQmZr0cXwUJElbAbRRtNTxHempigmCEQhzaC1OUN+0M+xOc4Z45Ir0XgcefdCzdwyEUFx1UyQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@jupyterlab/ui-components": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/domutils": "^1.1.3",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "@types/react": "~16.8.18",
-            "react": "~16.8.4",
-            "react-dom": "~16.8.4",
-            "sanitize-html": "~1.20.1"
-          }
-        },
-        "@jupyterlab/codeeditor": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-1.2.0.tgz",
-          "integrity": "sha512-toejhF/a80X10SZyvEnsnnlS9SxR5W4cz67ju7e/2lsZ8RMwZEDDJAJXyW3mw/EEjt8oVRNP2QpM8L5clE9XyQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/dragdrop": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/codemirror": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-1.2.1.tgz",
-          "integrity": "sha512-OtDe4BP9cn9OwY9xsk6foqf+qhnYBtuLIzjoUVbqS4IaHck7gTOA2T2AYBcAFQe9Aj0e/Bb5fo9jBhkVtiFHcA==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codeeditor": "^1.2.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@jupyterlab/statusbar": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "codemirror": "~5.47.0",
-            "react": "~16.8.4"
-          }
-        },
-        "@jupyterlab/coreutils": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.2.0.tgz",
-          "integrity": "sha512-LATiUsHuwze/h3JC2EZOBV+kGBoUKO3npqw/Pcgge4bz09xF/oTDrx4G8jl5eew3w1dCUNp9eLduNh8Orrw7xQ==",
-          "requires": {
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "ajv": "^6.5.5",
-            "json5": "^2.1.0",
-            "minimist": "~1.2.0",
-            "moment": "^2.24.0",
-            "path-posix": "~1.0.0",
-            "url-parse": "~1.4.3"
-          }
-        },
-        "@jupyterlab/docregistry": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-1.2.1.tgz",
-          "integrity": "sha512-EUj0c6VKB5YD7RrH/b4xyJLExNsgKNjysegLLN9dFGamz4azfylOJlbxqyN1n1GeLIG4rGsGT1pD7qzDlTQGEA==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codeeditor": "^1.2.0",
-            "@jupyterlab/codemirror": "^1.2.1",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@jupyterlab/rendermime": "^1.2.1",
-            "@jupyterlab/rendermime-interfaces": "^1.5.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/observables": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.4.0.tgz",
-          "integrity": "sha512-M/fhAnPqd6F4Zwt4IIsvHCkJmwbSw1Tko/hUXgdUQG86lPsJiTOh98sB3qwV1gtzb9oFF+kH21XsHnQZ6Yl6Pw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0"
-          }
-        },
-        "@jupyterlab/rendermime": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-1.2.1.tgz",
-          "integrity": "sha512-S57dOCQRXoGpUl9bGryAgAcLlDbXBk+Y8HPR2oO95slgk45vVktWl+6f/euNQcjOCX+RkuQuLLsBYeWzCZKCRw==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codemirror": "^1.2.1",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@jupyterlab/rendermime-interfaces": "^1.5.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "lodash.escape": "^4.0.1",
-            "marked": "^0.7.0"
-          }
-        },
-        "@jupyterlab/rendermime-interfaces": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.5.0.tgz",
-          "integrity": "sha512-k6DjX/srKl1FA1CZyrAzz1qA2v1arXUIAmbEddZ5L3O+dnvDlOKjkI/NexaRQvmQ62aziSln+wKrr2P1JPNmGg==",
-          "requires": {
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/services": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.2.0.tgz",
-          "integrity": "sha512-diqiWCYLROwZoeZ46hO4oCINQKr3S789GOA3drw5gDie18/u1nJcvegnY9Oo58xHINnKTs0rKZmFgTe2DvYgQg==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "node-fetch": "^2.6.0",
-            "ws": "^7.0.0"
-          }
-        },
-        "@jupyterlab/statusbar": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-1.2.1.tgz",
-          "integrity": "sha512-T+wmFQwW4tRHDDlY8A6i46G4HE7MP4EXMxcaNnYmPb+HElTgSx9KSrJ4cGRhFNdh5y0PcWwCD4wFUH5qAkEFYg==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codeeditor": "^1.2.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@jupyterlab/ui-components": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "react": "~16.8.4",
-            "typestyle": "^2.0.1"
-          }
-        },
-        "@jupyterlab/ui-components": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.2.1.tgz",
-          "integrity": "sha512-GUtIRwTmFnlJaPUM8SiFw1STmsyMVGjchLKqIoQnn0qYAJvaSUGyRqqoSD5iIpwov6OHCOOyxH6fQ5OAtH1kwA==",
-          "requires": {
-            "@blueprintjs/core": "^3.9.0",
-            "@blueprintjs/select": "^3.3.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "react": "~16.8.4",
-            "typestyle": "^2.0.1"
-          }
-        },
-        "marked": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
-        }
+        "@jupyterlab/apputils": "^2.0.0",
+        "@jupyterlab/coreutils": "^4.0.0",
+        "@jupyterlab/docmanager": "^2.0.0",
+        "@jupyterlab/docregistry": "^2.0.0",
+        "@jupyterlab/services": "^5.0.0",
+        "@jupyterlab/statedb": "^2.0.0",
+        "@jupyterlab/statusbar": "^2.0.0",
+        "@jupyterlab/ui-components": "^2.0.0",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/domutils": "^1.1.7",
+        "@lumino/dragdrop": "^1.5.1",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/polling": "^1.0.4",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1",
+        "react": "~16.9.0"
+      }
+    },
+    "@jupyterlab/nbformat": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-2.0.0.tgz",
+      "integrity": "sha512-TumS7G1fAeLhw07BtGdMUcuAaYEKGYXYov0LK/tDx99jSfdqMMrS+o4SlQKoZhZ/+xUwesmA/8L4dMkbYdyGgg==",
+      "requires": {
+        "@lumino/coreutils": "^1.4.2"
       }
     },
     "@jupyterlab/notebook": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/notebook/-/notebook-1.1.3.tgz",
-      "integrity": "sha512-AgKMhtWnGsPu3Pa/MwLLMU2u+MQXM3NPVuKYJi0fgHr+v1Xwh15nDNICKSEN9UA0JbK60sUGQssQvDbOPuNTBg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/notebook/-/notebook-2.0.0.tgz",
+      "integrity": "sha512-BOkrxCIydBgY70Sf4P+zkCiQfw7J5OEzZ+LfONxqMU/pY1vmKMiiDxOfex7RX8NfBG/P52zwlFRuXzPMWiAzxw==",
       "requires": {
-        "@jupyterlab/apputils": "^1.1.3",
-        "@jupyterlab/cells": "^1.1.3",
-        "@jupyterlab/codeeditor": "^1.1.0",
-        "@jupyterlab/coreutils": "^3.1.0",
-        "@jupyterlab/docregistry": "^1.1.3",
-        "@jupyterlab/observables": "^2.3.0",
-        "@jupyterlab/rendermime": "^1.1.3",
-        "@jupyterlab/services": "^4.1.1",
-        "@jupyterlab/statusbar": "^1.1.3",
-        "@jupyterlab/ui-components": "^1.1.2",
-        "@phosphor/algorithm": "^1.1.3",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/domutils": "^1.1.3",
-        "@phosphor/dragdrop": "^1.3.3",
-        "@phosphor/messaging": "^1.2.3",
-        "@phosphor/properties": "^1.1.3",
-        "@phosphor/signaling": "^1.2.3",
-        "@phosphor/virtualdom": "^1.1.3",
-        "@phosphor/widgets": "^1.8.0",
-        "react": "~16.8.4"
+        "@jupyterlab/apputils": "^2.0.0",
+        "@jupyterlab/cells": "^2.0.0",
+        "@jupyterlab/codeeditor": "^2.0.0",
+        "@jupyterlab/coreutils": "^4.0.0",
+        "@jupyterlab/docregistry": "^2.0.0",
+        "@jupyterlab/nbformat": "^2.0.0",
+        "@jupyterlab/observables": "^3.0.0",
+        "@jupyterlab/rendermime": "^2.0.0",
+        "@jupyterlab/services": "^5.0.0",
+        "@jupyterlab/statusbar": "^2.0.0",
+        "@jupyterlab/ui-components": "^2.0.0",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/domutils": "^1.1.7",
+        "@lumino/dragdrop": "^1.5.1",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1",
+        "@lumino/widgets": "^1.11.1",
+        "react": "~16.9.0"
       }
     },
     "@jupyterlab/observables": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.3.0.tgz",
-      "integrity": "sha512-I3Cmu0qUU3Emzai0MRBmiSHd1c42DtOuDYAru0/cvlI8xQKzin7t/EF9TahxSEBEDDNU4RRjADUYG9T3WefYtA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-3.0.0.tgz",
+      "integrity": "sha512-RN7wlWPzc5JGkRWBLWx+dbgAci0s3zOh2hixnUjxiokYvKARPmHUtLxxFa4YQUSm2iV0ynHYZwCImLtc0YAWsw==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.3",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.2.0",
-        "@phosphor/messaging": "^1.2.3",
-        "@phosphor/signaling": "^1.2.3"
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/signaling": "^1.3.5"
       }
     },
     "@jupyterlab/outputarea": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/outputarea/-/outputarea-1.2.2.tgz",
-      "integrity": "sha512-Eo2P4idncgQfPorjTCIFgP2K9GuOGxZ51ij88cbYiWonu2BEqqceGJCXuFGrnYLq6CaWsn9yhN6sIkr8WS+LEw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/outputarea/-/outputarea-2.0.0.tgz",
+      "integrity": "sha512-5/7vnKnjIg31dvfdnN24fTSsFO8oZalpVLLhssEAJhqEWUQY65owKZLmLPG0mGEKlpkMMSb82CE4TsInOsOtfQ==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/observables": "^2.4.0",
-        "@jupyterlab/rendermime": "^1.2.1",
-        "@jupyterlab/rendermime-interfaces": "^1.5.0",
-        "@jupyterlab/services": "^4.2.0",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/properties": "^1.1.3",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/widgets": "^1.9.0"
-      },
-      "dependencies": {
-        "@jupyterlab/apputils": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.2.1.tgz",
-          "integrity": "sha512-xp4GBpMJrK8DTLQmZr0cXwUJElbAbRRtNTxHempigmCEQhzaC1OUN+0M+xOc4Z45Ir0XgcefdCzdwyEUFx1UyQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@jupyterlab/ui-components": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/domutils": "^1.1.3",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "@types/react": "~16.8.18",
-            "react": "~16.8.4",
-            "react-dom": "~16.8.4",
-            "sanitize-html": "~1.20.1"
-          }
-        },
-        "@jupyterlab/codeeditor": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-1.2.0.tgz",
-          "integrity": "sha512-toejhF/a80X10SZyvEnsnnlS9SxR5W4cz67ju7e/2lsZ8RMwZEDDJAJXyW3mw/EEjt8oVRNP2QpM8L5clE9XyQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/dragdrop": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/codemirror": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-1.2.1.tgz",
-          "integrity": "sha512-OtDe4BP9cn9OwY9xsk6foqf+qhnYBtuLIzjoUVbqS4IaHck7gTOA2T2AYBcAFQe9Aj0e/Bb5fo9jBhkVtiFHcA==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codeeditor": "^1.2.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@jupyterlab/statusbar": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "codemirror": "~5.47.0",
-            "react": "~16.8.4"
-          }
-        },
-        "@jupyterlab/coreutils": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.2.0.tgz",
-          "integrity": "sha512-LATiUsHuwze/h3JC2EZOBV+kGBoUKO3npqw/Pcgge4bz09xF/oTDrx4G8jl5eew3w1dCUNp9eLduNh8Orrw7xQ==",
-          "requires": {
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "ajv": "^6.5.5",
-            "json5": "^2.1.0",
-            "minimist": "~1.2.0",
-            "moment": "^2.24.0",
-            "path-posix": "~1.0.0",
-            "url-parse": "~1.4.3"
-          }
-        },
-        "@jupyterlab/observables": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.4.0.tgz",
-          "integrity": "sha512-M/fhAnPqd6F4Zwt4IIsvHCkJmwbSw1Tko/hUXgdUQG86lPsJiTOh98sB3qwV1gtzb9oFF+kH21XsHnQZ6Yl6Pw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0"
-          }
-        },
-        "@jupyterlab/rendermime": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-1.2.1.tgz",
-          "integrity": "sha512-S57dOCQRXoGpUl9bGryAgAcLlDbXBk+Y8HPR2oO95slgk45vVktWl+6f/euNQcjOCX+RkuQuLLsBYeWzCZKCRw==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codemirror": "^1.2.1",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@jupyterlab/rendermime-interfaces": "^1.5.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "lodash.escape": "^4.0.1",
-            "marked": "^0.7.0"
-          }
-        },
-        "@jupyterlab/rendermime-interfaces": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.5.0.tgz",
-          "integrity": "sha512-k6DjX/srKl1FA1CZyrAzz1qA2v1arXUIAmbEddZ5L3O+dnvDlOKjkI/NexaRQvmQ62aziSln+wKrr2P1JPNmGg==",
-          "requires": {
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/services": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.2.0.tgz",
-          "integrity": "sha512-diqiWCYLROwZoeZ46hO4oCINQKr3S789GOA3drw5gDie18/u1nJcvegnY9Oo58xHINnKTs0rKZmFgTe2DvYgQg==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "node-fetch": "^2.6.0",
-            "ws": "^7.0.0"
-          }
-        },
-        "@jupyterlab/statusbar": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-1.2.1.tgz",
-          "integrity": "sha512-T+wmFQwW4tRHDDlY8A6i46G4HE7MP4EXMxcaNnYmPb+HElTgSx9KSrJ4cGRhFNdh5y0PcWwCD4wFUH5qAkEFYg==",
-          "requires": {
-            "@jupyterlab/apputils": "^1.2.1",
-            "@jupyterlab/codeeditor": "^1.2.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@jupyterlab/ui-components": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/widgets": "^1.9.0",
-            "react": "~16.8.4",
-            "typestyle": "^2.0.1"
-          }
-        },
-        "@jupyterlab/ui-components": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.2.1.tgz",
-          "integrity": "sha512-GUtIRwTmFnlJaPUM8SiFw1STmsyMVGjchLKqIoQnn0qYAJvaSUGyRqqoSD5iIpwov6OHCOOyxH6fQ5OAtH1kwA==",
-          "requires": {
-            "@blueprintjs/core": "^3.9.0",
-            "@blueprintjs/select": "^3.3.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "react": "~16.8.4",
-            "typestyle": "^2.0.1"
-          }
-        },
-        "marked": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
-        }
+        "@jupyterlab/apputils": "^2.0.0",
+        "@jupyterlab/nbformat": "^2.0.0",
+        "@jupyterlab/observables": "^3.0.0",
+        "@jupyterlab/rendermime": "^2.0.0",
+        "@jupyterlab/rendermime-interfaces": "^2.0.0",
+        "@jupyterlab/services": "^5.0.0",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1"
       }
     },
     "@jupyterlab/rendermime": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-1.2.1.tgz",
-      "integrity": "sha512-S57dOCQRXoGpUl9bGryAgAcLlDbXBk+Y8HPR2oO95slgk45vVktWl+6f/euNQcjOCX+RkuQuLLsBYeWzCZKCRw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-2.0.0.tgz",
+      "integrity": "sha512-vOCOwuG1UEqOnCZ/1U/cr5CUde+Wle6+OS1dRLu9srat57NpCysYcxXEih17d7dBTZnOQIXU5k2xAV8iDOHemA==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/codemirror": "^1.2.1",
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/observables": "^2.4.0",
-        "@jupyterlab/rendermime-interfaces": "^1.5.0",
-        "@jupyterlab/services": "^4.2.0",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/widgets": "^1.9.0",
+        "@jupyterlab/apputils": "^2.0.0",
+        "@jupyterlab/codemirror": "^2.0.0",
+        "@jupyterlab/coreutils": "^4.0.0",
+        "@jupyterlab/nbformat": "^2.0.0",
+        "@jupyterlab/observables": "^3.0.0",
+        "@jupyterlab/rendermime-interfaces": "^2.0.0",
+        "@jupyterlab/services": "^5.0.0",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1",
         "lodash.escape": "^4.0.1",
-        "marked": "^0.7.0"
-      },
-      "dependencies": {
-        "@jupyterlab/apputils": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.2.1.tgz",
-          "integrity": "sha512-xp4GBpMJrK8DTLQmZr0cXwUJElbAbRRtNTxHempigmCEQhzaC1OUN+0M+xOc4Z45Ir0XgcefdCzdwyEUFx1UyQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/services": "^4.2.0",
-            "@jupyterlab/ui-components": "^1.2.1",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/domutils": "^1.1.3",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "@types/react": "~16.8.18",
-            "react": "~16.8.4",
-            "react-dom": "~16.8.4",
-            "sanitize-html": "~1.20.1"
-          }
-        },
-        "@jupyterlab/coreutils": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.2.0.tgz",
-          "integrity": "sha512-LATiUsHuwze/h3JC2EZOBV+kGBoUKO3npqw/Pcgge4bz09xF/oTDrx4G8jl5eew3w1dCUNp9eLduNh8Orrw7xQ==",
-          "requires": {
-            "@phosphor/commands": "^1.7.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/properties": "^1.1.3",
-            "@phosphor/signaling": "^1.3.0",
-            "ajv": "^6.5.5",
-            "json5": "^2.1.0",
-            "minimist": "~1.2.0",
-            "moment": "^2.24.0",
-            "path-posix": "~1.0.0",
-            "url-parse": "~1.4.3"
-          }
-        },
-        "@jupyterlab/observables": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.4.0.tgz",
-          "integrity": "sha512-M/fhAnPqd6F4Zwt4IIsvHCkJmwbSw1Tko/hUXgdUQG86lPsJiTOh98sB3qwV1gtzb9oFF+kH21XsHnQZ6Yl6Pw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0"
-          }
-        },
-        "@jupyterlab/rendermime-interfaces": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.5.0.tgz",
-          "integrity": "sha512-k6DjX/srKl1FA1CZyrAzz1qA2v1arXUIAmbEddZ5L3O+dnvDlOKjkI/NexaRQvmQ62aziSln+wKrr2P1JPNmGg==",
-          "requires": {
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/widgets": "^1.9.0"
-          }
-        },
-        "@jupyterlab/services": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.2.0.tgz",
-          "integrity": "sha512-diqiWCYLROwZoeZ46hO4oCINQKr3S789GOA3drw5gDie18/u1nJcvegnY9Oo58xHINnKTs0rKZmFgTe2DvYgQg==",
-          "requires": {
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@jupyterlab/observables": "^2.4.0",
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/disposable": "^1.3.0",
-            "@phosphor/signaling": "^1.3.0",
-            "node-fetch": "^2.6.0",
-            "ws": "^7.0.0"
-          }
-        },
-        "@jupyterlab/ui-components": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.2.1.tgz",
-          "integrity": "sha512-GUtIRwTmFnlJaPUM8SiFw1STmsyMVGjchLKqIoQnn0qYAJvaSUGyRqqoSD5iIpwov6OHCOOyxH6fQ5OAtH1kwA==",
-          "requires": {
-            "@blueprintjs/core": "^3.9.0",
-            "@blueprintjs/select": "^3.3.0",
-            "@jupyterlab/coreutils": "^3.2.0",
-            "@phosphor/coreutils": "^1.3.1",
-            "@phosphor/messaging": "^1.3.0",
-            "@phosphor/virtualdom": "^1.2.0",
-            "@phosphor/widgets": "^1.9.0",
-            "react": "~16.8.4",
-            "typestyle": "^2.0.1"
-          }
-        }
+        "marked": "^0.8.0"
       }
     },
     "@jupyterlab/rendermime-interfaces": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.4.0.tgz",
-      "integrity": "sha512-6GtbudtK7Yl37ldnQUQ6hTUDzjVgemiDXokEdsSTLPOPoPwKw3gaEBfxrOz/LBITfqIfbpuBzYU8lQ4rHq0TfQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-2.0.0.tgz",
+      "integrity": "sha512-1BRpxIppycFmJtV5kq+BVcQT80k3PflMmDsSITXFUspX20SiEktjZcSfzUplTwkp6pSXlr2QCLTV2rQE00dGNA==",
       "requires": {
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/widgets": "^1.8.0"
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/widgets": "^1.11.1"
       }
     },
     "@jupyterlab/services": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.1.1.tgz",
-      "integrity": "sha512-HuayhkG+g5T4sZ1cKEJmF9KkCLnOMpcx+e5bk2cmTc3i3ByF5lp9EZOdkqG7OBc0pQz/6EaPcuiEGSHsV2706Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-5.0.0.tgz",
+      "integrity": "sha512-j1dJ1FdoZu+VhCz+v3SqOHVTp4r1kDTS3QCbjllMYbA0nuq1a1M4FfdlZKPuiKbAHWN3nZe2boDqFRAOhLCPuQ==",
       "requires": {
-        "@jupyterlab/coreutils": "^3.1.0",
-        "@jupyterlab/observables": "^2.3.0",
-        "@phosphor/algorithm": "^1.1.3",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.2.0",
-        "@phosphor/signaling": "^1.2.3",
+        "@jupyterlab/coreutils": "^4.0.0",
+        "@jupyterlab/nbformat": "^2.0.0",
+        "@jupyterlab/observables": "^3.0.0",
+        "@jupyterlab/settingregistry": "^2.0.0",
+        "@jupyterlab/statedb": "^2.0.0",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/polling": "^1.0.4",
+        "@lumino/signaling": "^1.3.5",
         "node-fetch": "^2.6.0",
-        "ws": "^7.0.0"
+        "ws": "^7.2.0"
+      }
+    },
+    "@jupyterlab/settingregistry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-2.0.0.tgz",
+      "integrity": "sha512-wetj5bCdvyRaNqadgzUwMK0+IjcbOfK9m1pb4MEK4nQfxfXOJ5eKjH7R99yNK4GgE5z8cDQ/UtyJZn/QdfHfZQ==",
+      "requires": {
+        "@jupyterlab/statedb": "^2.0.0",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/signaling": "^1.3.5",
+        "ajv": "^6.10.2",
+        "json5": "^2.1.1"
+      }
+    },
+    "@jupyterlab/statedb": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-2.0.0.tgz",
+      "integrity": "sha512-bBK0urGUVMlid8Gq7lQbap35hU91VbOR8aQbZFkK4pha+9y5CsiP4eFoVTLlPY+9soTV2bROAzXLnROD3O9Ndg==",
+      "requires": {
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5"
       }
     },
     "@jupyterlab/statusbar": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-1.1.3.tgz",
-      "integrity": "sha512-bBJpFEFuTb/ARkDBFopqo5atU3JfZHqbytxqQv6YA/mzYCVQwCdLSJyc+vQniE+xWhoYIqd7q5g17lnxNioDLw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-2.0.0.tgz",
+      "integrity": "sha512-JFRecSRZmTW1gnrmYnNMY0kyNA5XMJZDs6HFbREQm21AKMzOZJ3/2c2SoXos5wR664rz5Rb+Uo37xdmuAVvDgg==",
       "requires": {
-        "@jupyterlab/apputils": "^1.1.3",
-        "@jupyterlab/codeeditor": "^1.1.0",
-        "@jupyterlab/coreutils": "^3.1.0",
-        "@jupyterlab/services": "^4.1.1",
-        "@jupyterlab/ui-components": "^1.1.2",
-        "@phosphor/algorithm": "^1.1.3",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.2.0",
-        "@phosphor/messaging": "^1.2.3",
-        "@phosphor/signaling": "^1.2.3",
-        "@phosphor/widgets": "^1.8.0",
-        "react": "~16.8.4",
-        "typestyle": "^2.0.1"
+        "@jupyterlab/apputils": "^2.0.0",
+        "@jupyterlab/codeeditor": "^2.0.0",
+        "@jupyterlab/coreutils": "^4.0.0",
+        "@jupyterlab/services": "^5.0.0",
+        "@jupyterlab/ui-components": "^2.0.0",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/polling": "^1.0.4",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1",
+        "react": "~16.9.0",
+        "typestyle": "^2.0.4"
       }
     },
     "@jupyterlab/ui-components": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.1.2.tgz",
-      "integrity": "sha512-FdBe5Dkbt4YduaB34Cc9gHiLCzfqfs0V+SoDbyA3bKVjp12wtg27dG2nhlGOSKhZL3VcnXbfPb7w27JZ/1b4Ig==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-2.0.0.tgz",
+      "integrity": "sha512-SNojvg37k/jwL5C6lwvZu/+Oge3DbGnnkNmKiExp2YwauVDSSMV88EIkWGo6t1nZPBDHB0j8lb9SEMs+9j59zQ==",
       "requires": {
-        "@blueprintjs/core": "^3.9.0",
-        "@blueprintjs/select": "^3.3.0",
-        "@jupyterlab/coreutils": "^3.1.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/messaging": "^1.2.3",
-        "@phosphor/virtualdom": "^1.1.3",
-        "@phosphor/widgets": "^1.8.0",
-        "react": "~16.8.4",
-        "typestyle": "^2.0.1"
+        "@blueprintjs/core": "^3.22.2",
+        "@blueprintjs/select": "^3.11.2",
+        "@jupyterlab/coreutils": "^4.0.0",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1",
+        "@lumino/widgets": "^1.11.1",
+        "react": "~16.9.0",
+        "react-dom": "~16.9.0",
+        "typestyle": "^2.0.4"
       }
     },
-    "@phosphor/algorithm": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-      "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
+    "@lumino/algorithm": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-1.2.3.tgz",
+      "integrity": "sha512-XBJ/homcm7o8Y9G6MzYvf0FF7SVqUCzvkIO01G2mZhCOnkZZhZ9c4uNOcE2VjSHNxHv2WU0l7d8rdhyKhmet+A=="
     },
-    "@phosphor/application": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/application/-/application-1.7.3.tgz",
-      "integrity": "sha512-ohxrW7rv5Tms4PSyPRZT6YArZQQGQNG4MgTeFzkoLJ+7mp/BcbFuvEoaV1/CUKQArofl0DCkKDOTOIkXP+/32A==",
+    "@lumino/application": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@lumino/application/-/application-1.8.4.tgz",
+      "integrity": "sha512-f+CgggJ/9jopHT6db76+BjsiPBHjv6fgReU/vKtRGg8rsDjNRDefoWd9bWGWRuPiGymBY8c/+9Kyq5v0UDs5vg==",
       "requires": {
-        "@phosphor/commands": "^1.7.2",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/widgets": "^1.9.3"
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/widgets": "^1.11.1"
       }
     },
-    "@phosphor/collections": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.2.0.tgz",
-      "integrity": "sha512-T9/0EjSuY6+ga2LIFRZ0xupciOR3Qnyy8Q95lhGTC0FXZUFwC8fl9e8On6IcwasCszS+1n8dtZUWSIynfgdpzw==",
+    "@lumino/collections": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lumino/collections/-/collections-1.2.3.tgz",
+      "integrity": "sha512-lrSTb7kru/w8xww8qWqHHhHO3GkoQeXST2oNkOEbWNEO4wuBIHoKPSOmXpUwu58UykBUfd5hL5wbkeTzyNMONg==",
       "requires": {
-        "@phosphor/algorithm": "^1.2.0"
+        "@lumino/algorithm": "^1.2.3"
       }
     },
-    "@phosphor/commands": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/commands/-/commands-1.7.2.tgz",
-      "integrity": "sha512-iSyBIWMHsus323BVEARBhuVZNnVel8USo+FIPaAxGcq+icTSSe6+NtSxVQSmZblGN6Qm4iw6I6VtiSx0e6YDgQ==",
+    "@lumino/commands": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.10.1.tgz",
+      "integrity": "sha512-HGtXtqKD1WZJszJ42u2DyM3sgxrLal66IoHSJjbn2ygcEVCKDK73NSzoaQtXFtiissMedzKl8aIRXB3uyeEOlw==",
       "requires": {
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.1",
-        "@phosphor/domutils": "^1.1.4",
-        "@phosphor/keyboard": "^1.1.3",
-        "@phosphor/signaling": "^1.3.1"
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/domutils": "^1.1.7",
+        "@lumino/keyboard": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1"
       }
     },
-    "@phosphor/coreutils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@phosphor/coreutils/-/coreutils-1.3.1.tgz",
-      "integrity": "sha512-9OHCn8LYRcPU/sbHm5v7viCA16Uev3gbdkwqoQqlV+EiauDHl70jmeL7XVDXdigl66Dz0LI11C99XOxp+s3zOA=="
+    "@lumino/coreutils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-1.4.2.tgz",
+      "integrity": "sha512-SmQ4YDANe25rZd0bLoW7LVAHmgySjkrJmyNPnPW0GrpBt2u4/6D+EQJ8PCCMNWuJvrljBCdlmgOFsT38qYhfcw=="
     },
-    "@phosphor/disposable": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.3.1.tgz",
-      "integrity": "sha512-0NGzoTXTOizWizK/brKKd5EjJhuuEH4903tLika7q6wl/u0tgneJlTh7R+MBVeih0iNxtuJAfBa3IEY6Qmj+Sw==",
+    "@lumino/disposable": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-1.3.5.tgz",
+      "integrity": "sha512-IWDAd+nysBnwLhEtW7M62PVk84OEex9OEktZsS6V+19n/o8/Rw4ccL0pt0GFby01CsVK0YcELDoDaMUZsMiAmA==",
       "requires": {
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/signaling": "^1.3.1"
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/signaling": "^1.3.5"
       }
     },
-    "@phosphor/domutils": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@phosphor/domutils/-/domutils-1.1.4.tgz",
-      "integrity": "sha512-ivwq5TWjQpKcHKXO8PrMl+/cKqbgxPClPiCKc1gwbMd+6hnW5VLwNG0WBzJTxCzXK43HxX18oH+tOZ3E04wc3w=="
+    "@lumino/domutils": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-1.1.7.tgz",
+      "integrity": "sha512-NPysY8XfpCvLNvDe+z1caIUPxOLXWRPQMUAjOj/EhggRyXadan6Lm/5uO6M9S5gW/v9QUXT4+1Sxe3WXz0nRCA=="
     },
-    "@phosphor/dragdrop": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@phosphor/dragdrop/-/dragdrop-1.4.1.tgz",
-      "integrity": "sha512-77paMoubIWk7pdwA2GVFkqba1WP48hTZZvS17N30+KVOeWfSqBL3flPSnW2yC4y6FnOP2PFOCtuPIbQv+pYhCA==",
+    "@lumino/dragdrop": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-1.5.1.tgz",
+      "integrity": "sha512-MFg/hy6hHdPwBZypBue5mlrBzjoNrtBQzzJW+kbM5ftAOvS99ZRgyMMlMQcbsHd+6yib9NOQ64Hd8P8uZEWTdw==",
       "requires": {
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.1"
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5"
       }
     },
-    "@phosphor/keyboard": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/keyboard/-/keyboard-1.1.3.tgz",
-      "integrity": "sha512-dzxC/PyHiD6mXaESRy6PZTd9JeK+diwG1pyngkyUf127IXOEzubTIbu52VSdpGBklszu33ws05BAGDa4oBE4mQ=="
+    "@lumino/keyboard": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-1.1.6.tgz",
+      "integrity": "sha512-W6pqe0TXRfGOoz1ZK1PRmuGZUWpmdoJArrzwmduUf0t2r06yl56S7w76gxrB7ExTidNPPaOWydGIosPgdgZf5A=="
     },
-    "@phosphor/messaging": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.3.0.tgz",
-      "integrity": "sha512-k0JE+BTMKlkM335S2AmmJxoYYNRwOdW5jKBqLgjJdGRvUQkM0+2i60ahM45+J23atGJDv9esKUUBINiKHFhLew==",
+    "@lumino/messaging": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lumino/messaging/-/messaging-1.3.3.tgz",
+      "integrity": "sha512-J+0m1aywl64I9/dr9fzE9IwC+eq90T5gUi1hCXP1MFnZh4aLUymmRV5zFw1CNh/vYlNnEu72xxEuhfCfuhiy8g==",
       "requires": {
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/collections": "^1.2.0"
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/collections": "^1.2.3"
       }
     },
-    "@phosphor/properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/properties/-/properties-1.1.3.tgz",
-      "integrity": "sha512-GiglqzU77s6+tFVt6zPq9uuyu/PLQPFcqZt914ZhJ4cN/7yNI/SLyMzpYZ56IRMXvzK9TUgbRna6URE3XAwFUg=="
-    },
-    "@phosphor/signaling": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.3.1.tgz",
-      "integrity": "sha512-Eq3wVCPQAhUd9+gUGaYygMr+ov7dhSGblSBXiDzpZlSIfa8OVD4P3cCvYXr/acDTNmZ/gHTcSFO8/n3rDkeXzg==",
+    "@lumino/polling": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lumino/polling/-/polling-1.0.4.tgz",
+      "integrity": "sha512-9OYIDTohToj6SLrxOr+FbeyPvirBU/r53FgmPxulcDgUVnVk4tqTSLIJAUu3mjJd9hnmZZqpSn9ppyjQAo3qSg==",
       "requires": {
-        "@phosphor/algorithm": "^1.2.0"
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/signaling": "^1.3.5"
       }
     },
-    "@phosphor/virtualdom": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@phosphor/virtualdom/-/virtualdom-1.2.0.tgz",
-      "integrity": "sha512-L9mKNhK2XtVjzjuHLG2uYuepSz8uPyu6vhF4EgCP0rt0TiLYaZeHwuNu3XeFbul9DMOn49eBpye/tfQVd4Ks+w==",
+    "@lumino/properties": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-1.1.6.tgz",
+      "integrity": "sha512-QnZa1IB7sr4Tawf0OKvwgZAptxDRK7DUAMJ71zijXNXH4FlxyThzOWXef51HHFsISKYa8Rn3rysOwtc62XkmXw=="
+    },
+    "@lumino/signaling": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-1.3.5.tgz",
+      "integrity": "sha512-6jniKrLrJOXKJmaJyU7hr6PBzE4GJ5Wms5hc/yzNKKDBxGSEPdtNJlW3wTNUuSTTtF/9ItN8A8ZC/G0yIu53Tw==",
       "requires": {
-        "@phosphor/algorithm": "^1.2.0"
+        "@lumino/algorithm": "^1.2.3"
       }
     },
-    "@phosphor/widgets": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/widgets/-/widgets-1.9.3.tgz",
-      "integrity": "sha512-61jsxloDrW/+WWQs8wOgsS5waQ/MSsXBuhONt0o6mtdeL93HVz7CYO5krOoot5owammfF6oX1z0sDaUYIYgcPA==",
+    "@lumino/virtualdom": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.6.1.tgz",
+      "integrity": "sha512-+KdzSw8TCPwvK6qhZr4xTyp6HymvEb2Da0xPdi4RsVUNhYf2gBI03uidXHx76Vx5OIbEgCn1B+0srxvm2ZbWsQ==",
       "requires": {
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/commands": "^1.7.2",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.1",
-        "@phosphor/domutils": "^1.1.4",
-        "@phosphor/dragdrop": "^1.4.1",
-        "@phosphor/keyboard": "^1.1.3",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/properties": "^1.1.3",
-        "@phosphor/signaling": "^1.3.1",
-        "@phosphor/virtualdom": "^1.2.0"
+        "@lumino/algorithm": "^1.2.3"
+      }
+    },
+    "@lumino/widgets": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.11.1.tgz",
+      "integrity": "sha512-f4QDe6lVNPcjL8Vb20BiP0gzbT1rx0/1Hc719u5oW9c0Z/xrXMWwNhnb/zYM/kBBVBe3omLmCfJOiNuE0oZl0A==",
+      "requires": {
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/domutils": "^1.1.7",
+        "@lumino/dragdrop": "^1.5.1",
+        "@lumino/keyboard": "^1.1.6",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1"
       }
     },
     "@types/backbone": {
@@ -1817,9 +654,9 @@
       "dev": true
     },
     "@types/jquery": {
-      "version": "3.3.31",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.31.tgz",
-      "integrity": "sha512-Lz4BAJihoFw5nRzKvg4nawXPzutkv7wmfQ5121avptaSIXlDNJCUuxZxX/G+9EVidZGuO0UBlk+YjKbwRKJigg==",
+      "version": "3.3.33",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.33.tgz",
+      "integrity": "sha512-U6IdXYGkfUI42SR79vB2Spj+h1Ly3J3UZjpd8mi943lh126TK7CB+HZOxGh2nM3IySor7wqVQdemD/xtydsBKA==",
       "requires": {
         "@types/sizzle": "*"
       }
@@ -1831,9 +668,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.144",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.144.tgz",
-      "integrity": "sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg=="
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
     },
     "@types/prop-types": {
       "version": "15.7.3",
@@ -1841,9 +678,9 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "16.8.25",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.25.tgz",
-      "integrity": "sha512-ydAAkLnNTC4oYSxJ3zwK/4QcVmEecACJ4ZdxXITbxz/dhahBSDKY6OQ1uawAW6rE/7kfHccxulYLSAIZVrSq0A==",
+      "version": "16.9.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.23.tgz",
+      "integrity": "sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -1855,9 +692,9 @@
       "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
     },
     "@types/underscore": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.9.3.tgz",
-      "integrity": "sha512-SwbHKB2DPIDlvYqtK5O+0LFtZAyrUSw4c0q+HWwmH1Ve3KMQ0/5PlV3RX97+3dP7yMrnNQ8/bCWWvQpPl03Mug=="
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.9.4.tgz",
+      "integrity": "sha512-CjHWEMECc2/UxOZh0kpiz3lEyX2Px3rQS9HzD20lxMvx571ivOBQKeLnqEjxUY0BMgp6WJWo/pQLRBwMW5v4WQ=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.4.0",
@@ -2263,11 +1100,6 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
-    },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "atob": {
       "version": "2.1.2",
@@ -2708,9 +1540,9 @@
       }
     },
     "codemirror": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.47.0.tgz",
-      "integrity": "sha512-kV49Fr+NGFHFc/Imsx6g180hSlkGhuHxTSDDmDHOuyln0MQYFLixDY4+bFkBVeCEiepYfDimAF/e++9jPJk4QA=="
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.49.2.tgz",
+      "integrity": "sha512-dwJ2HRPHm8w51WB5YTF9J7m6Z5dtkqbU9ntMZ1dqXyFB9IpjoUFDj80ahRVEoVanfIp6pfASJbOlbWdEf8FOzQ=="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -2939,9 +1771,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
-      "integrity": "sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ=="
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
+      "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -2970,11 +1802,32 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
     },
     "define-property": {
       "version": "2.0.2",
@@ -3062,9 +1915,9 @@
       }
     },
     "dom-serializer": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
-      "integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
       "requires": {
         "domelementtype": "^2.0.1",
         "entities": "^2.0.0"
@@ -3260,6 +2113,34 @@
       "dev": true,
       "requires": {
         "prr": "~1.0.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "escape-string-regexp": {
@@ -3740,11 +2621,6 @@
         }
       }
     },
-    "font-awesome": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -3864,6 +2740,11 @@
       "dev": true,
       "optional": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -3969,10 +2850,23 @@
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -4218,6 +3112,11 @@
         }
       }
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -4232,6 +3131,11 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -4252,6 +3156,11 @@
           }
         }
       }
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -4320,11 +3229,27 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -4571,9 +3496,9 @@
       }
     },
     "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
+      "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -5065,6 +3990,21 @@
         }
       }
     },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+    },
+    "object-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -5072,6 +4012,17 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.pick": {
@@ -5334,9 +4285,9 @@
       }
     },
     "popper.js": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
-      "integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw=="
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -5345,9 +4296,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
-      "integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+      "integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -5499,31 +4450,30 @@
       }
     },
     "react": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
+      "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "prop-types": "^15.6.2"
       }
     },
     "react-dom": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
+      "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "scheduler": "^0.15.0"
       }
     },
     "react-is": {
-      "version": "16.10.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
-      "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
+      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -5531,12 +4481,13 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-popper": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.4.tgz",
-      "integrity": "sha512-9AcQB29V+WrBKk6X7p0eojd1f25/oJajVdMZkywIoAV6Ag7hzE1Mhyeup2Q1QnvFRtGQFQvtqfhlEoDAPfKAVA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "create-react-context": "^0.3.0",
+        "deep-equal": "^1.1.1",
         "popper.js": "^1.14.4",
         "prop-types": "^15.6.1",
         "typed-styles": "^0.0.7",
@@ -5555,9 +4506,9 @@
       }
     },
     "readable-stream": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-      "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -5586,6 +4537,15 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "regexpp": {
@@ -5786,9 +4746,9 @@
       }
     },
     "scheduler": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
+      "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -6249,6 +5209,24 @@
         }
       }
     },
+    "string.prototype.trimleft": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -6487,7 +5465,8 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.17.1",
@@ -6546,9 +5525,9 @@
       }
     },
     "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
     },
     "union-value": {
       "version": "1.0.1",
@@ -7659,12 +6638,9 @@
       }
     },
     "ws": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
-      "integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
-      "requires": {
-        "async-limiter": "^1.0.0"
-      }
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
     "url": "https://github.com/bokeh/jupyter_bokeh.git"
   },
   "dependencies": {
-    "@jupyterlab/application": "^1.1.3",
-    "@jupyterlab/apputils": "^1.1.3",
-    "@jupyterlab/docregistry": "^1.1.3",
-    "@jupyterlab/notebook": "^1.1.3",
-    "@jupyterlab/rendermime-interfaces": "^1.4.0",
-    "@jupyterlab/services": "^4.1.1",
-    "@jupyter-widgets/base": "^2.0.1",
-    "@phosphor/coreutils": "^1.3.1",
-    "@phosphor/disposable": "^1.3.1",
-    "@phosphor/widgets": "^1.9.3"
+    "@jupyterlab/application": "^2.0.0",
+    "@jupyterlab/apputils": "^2.0.0",
+    "@jupyterlab/docregistry": "^2.0.0",
+    "@jupyterlab/notebook": "^2.0.0",
+    "@jupyterlab/rendermime-interfaces": "^2.0.0",
+    "@jupyterlab/services": "^5.0.0",
+    "@jupyter-widgets/base": "^3.0.0",
+    "@lumino/coreutils": "^1.3.1",
+    "@lumino/disposable": "^1.3.1",
+    "@lumino/widgets": "^1.9.3"
   },
   "devDependencies": {
     "rimraf": "^3.0.0",

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1,4 +1,4 @@
-import {IDisposable} from "@phosphor/disposable"
+import {IDisposable} from "@lumino/disposable"
 import {DocumentRegistry} from "@jupyterlab/docregistry"
 
 /**

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,7 +2,7 @@ import {DocumentRegistry} from "@jupyterlab/docregistry"
 import {INotebookModel, NotebookPanel} from "@jupyterlab/notebook"
 import {JupyterFrontEndPlugin, JupyterFrontEnd} from "@jupyterlab/application"
 import {IJupyterWidgetRegistry} from "@jupyter-widgets/base"
-import {IDisposable, DisposableDelegate} from "@phosphor/disposable"
+import {IDisposable, DisposableDelegate} from "@lumino/disposable"
 
 import {ContextManager} from "./manager"
 import {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,7 +1,7 @@
 import {IRenderMime} from "@jupyterlab/rendermime-interfaces"
 import {KernelMessage, Kernel} from "@jupyterlab/services"
-import {ReadonlyJSONObject} from "@phosphor/coreutils"
-import {Widget} from "@phosphor/widgets"
+import {ReadonlyJSONObject} from "@lumino/coreutils"
+import {Widget} from "@lumino/widgets"
 import {ContextManager} from "./manager"
 
 export declare interface KernelProxy {
@@ -76,13 +76,13 @@ export class BokehJSExec extends Widget implements IRenderMime.IRenderer {
         const {_manager} = this
         const kernel_proxy: KernelProxy = {
           registerCommTarget(targetName, callback) {
-            const {kernel} = _manager!.context.session
+            const kernel = _manager!.context.sessionContext.session?.kernel
             if (kernel != null)
               kernel.registerCommTarget(targetName, callback)
           },
         }
         Bokeh.embed.kernels[this._document_id] = kernel_proxy
-        _manager!.context.session.statusChanged.connect((_session, status) => {
+        _manager!.context.sessionContext.statusChanged.connect((_session, status) => {
           if (status == "restarting" || status === "dead") {
             delete Bokeh.embed.kernels[this._document_id!]
           }
@@ -114,7 +114,7 @@ export class BokehJSExec extends Widget implements IRenderMime.IRenderer {
       const content: KernelMessage.IExecuteRequestMsg["content"] = {
         code: `import bokeh.io.notebook as ion; ion.destroy_server("${this._server_id}")`,
       }
-      const {kernel} = this._manager!.context.session
+      const kernel = this._manager!.context.sessionContext.session?.kernel
       if (kernel != null)
         kernel.requestExecute(content, true)
       this._server_id = null


### PR DESCRIPTION
JupyterLab 2.0.0 is out, and this extension have conflicting dependencies with its core packages. Fixes #88.

```
Conflicting Dependencies:
JupyterLab                        Extension      Package
>=2.0.0 <2.1.0                    >=1.1.3 <2.0.0 @jupyterlab/application
>=2.0.0 <2.1.0                    >=1.1.3 <2.0.0 @jupyterlab/apputils
>=2.0.0 <2.1.0                    >=1.1.3 <2.0.0 @jupyterlab/notebook
>=2.0.0 <2.1.0                    >=1.4.0 <2.0.0 @jupyterlab/rendermime-interfaces
>=5.0.0 <5.1.0                    >=4.1.1 <5.0.0 @jupyterlab/services
```

## Implementation notes

There was some manual changes needed in the code due to the following part in the JupyterLab migration guide: https://jupyterlab.readthedocs.io/en/stable/developer/extension_migration.html#using-session-and-sessioncontext-to-manage-kernel-sessions

I did my best to ensure I didn't get install / build errors, and made a guess on how to fix it. I have not tested this code in a JupyterLab UI yet.

## References
- [Change log for developers](https://jupyterlab.readthedocs.io/en/stable/getting_started/changelog.html#for-developers)
- [A migration guide](https://jupyterlab.readthedocs.io/en/stable/developer/extension_migration.html#extension-migration)