### PR TITLE
Add option to combine events and support other events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,14 @@ cache:
 install:
 - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 - bash miniconda.sh -b -p $HOME/miniconda
-- export PATH="$HOME/miniconda/bin:$PATH"
+- source "$HOME/miniconda/etc/profile.d/conda.sh"
 - hash -r
 - conda config --set always_yes yes
 - conda config --set quiet yes
 - conda config --set changeps1 no
 - conda config --add channels bokeh
 - conda config --add channels conda-forge
+- conda update -q conda
 - conda info -a
 - conda install conda-build nodejs jupyterlab notebook
 - npm set progress false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ install:
 - conda config --add channels conda-forge
 - conda update -q conda
 - conda info -a
-- conda install conda-build nodejs jupyterlab notebook
+- conda create -n test_env conda-build nodejs jupyterlab notebook
+- conda activate test_env
 - npm set progress false
 - npm install -g npm
 - conda build conda.recipe/

--- a/jupyter_bokeh/widgets.py
+++ b/jupyter_bokeh/widgets.py
@@ -23,12 +23,13 @@ from traitlets import Bool, Dict, Unicode
 
 # Bokeh imports
 from bokeh.core.json_encoder import serialize_json
-from bokeh.models import LayoutDOM
 from bokeh.document import Document
-from bokeh.protocol import Protocol
-from bokeh.util.dependencies import import_optional
 from bokeh.embed.elements import div_for_render_item
 from bokeh.embed.util import standalone_docs_json_and_render_items
+from bokeh.events import Event
+from bokeh.models import LayoutDOM
+from bokeh.protocol import Protocol
+from bokeh.util.dependencies import import_optional
 
 #-----------------------------------------------------------------------------
 # Globals and constants
@@ -105,15 +106,31 @@ class BokehModel(DOMWidget):
     def _sync_model(self, _, content, _buffers):
         if content.get("event", "") != "jsevent":
             return
-        new, old, attr = content["new"], content["old"], content["attr"]
-        submodel = self._model.select_one({"id": content["id"]})
-        descriptor = submodel.lookup(content['attr'])
-        try:
-            descriptor._real_set(submodel, old, new, setter=self)
-        except Exception:
-            return
-        for cb in submodel._callbacks.get(attr, []):
-            cb(attr, old, new)
+        kind = content.get("kind")
+        if kind == 'ModelChanged':
+            hint = content.get("hint")
+            if hint:
+                cds = self._model.select_one({"id": hint["column_source"]["id"]})
+                if "patches" in hint:
+                    # Handle ColumnsPatchedEvent
+                    cds.patch(hint["patches"], setter=self)
+                elif "data" in hint:
+                    # Handle ColumnsStreamedEvent
+                    cds._stream(hint["data"], rollover=hint["rollover"], setter=self)
+                return
+
+            # Handle ModelChangedEvent
+            new, old, attr = content["new"], content["old"], content["attr"]
+            submodel = self._model.select_one({"id": content["id"]})
+            descriptor = submodel.lookup(content['attr'])
+            try:
+                descriptor._real_set(submodel, old, new, hint=hint, setter=self)
+            except Exception:
+                return
+            for cb in submodel._callbacks.get(attr, []):
+                cb(attr, old, new)
+        elif kind == 'MessageSent':
+            self._document.apply_json_event(content["msg_data"])
 
 #-----------------------------------------------------------------------------
 # Dev API

--- a/jupyter_bokeh/widgets.py
+++ b/jupyter_bokeh/widgets.py
@@ -19,7 +19,7 @@ import json
 
 # External imports
 from ipywidgets import DOMWidget
-from traitlets import Unicode, Dict
+from traitlets import Bool, Dict, Unicode
 
 # Bokeh imports
 from bokeh.core.json_encoder import serialize_json
@@ -55,6 +55,7 @@ class BokehModel(DOMWidget):
     _view_module = Unicode(_module_name).tag(sync=True)
     _view_module_version = Unicode(_module_version).tag(sync=True)
 
+    combine_events = Bool(False).tag(sync=True)
     render_bundle = Dict().tag(sync=True, to_json=lambda obj, _: serialize_json(obj))
 
     @property

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -27,6 +27,42 @@ export type RenderBundle = {
   div: string
 }
 
+export interface DocumentChanged {
+  event: "jsevent"
+  kind: string
+}
+
+export interface ModelChanged extends DocumentChanged {
+  event: "jsevent"
+  kind: "ModelChanged"
+  id: string
+  new: unknown
+  attr: string
+  old: unknown
+  hint: unknown
+}
+
+export interface MessageSent extends DocumentChanged {
+  event: "jsevent"
+  kind: "MessageSent"
+  msg_data: {
+    event_name: string,
+    event_values: {
+      model: {id: string},
+      [other: string]: any
+    }
+  }
+  msg_type: string
+}
+
+function isModelChanged(msg: DocumentChanged): msg is ModelChanged {
+  return (msg as ModelChanged).kind === "ModelChanged"
+}
+
+function isMessageSent(msg: DocumentChanged): msg is MessageSent {
+  return (msg as MessageSent).kind === "MessageSent"
+}
+
 export class BokehModel extends DOMWidgetModel {
   defaults() {
     return {
@@ -56,26 +92,32 @@ export class BokehView extends DOMWidgetView {
   private _blocked: boolean
   private _msgs: any[]
   private _idle: boolean
+  private _combine: boolean
 
   constructor(options?: any) {
     super(options)
     this._document = null
     this._blocked = false
     this._idle = true
+    this._combine = true
     this._msgs = []
     const {Receiver} = bk_require("protocol/receiver")
     this._receiver = new Receiver()
     this.model.on("change:render_bundle", () => this.render())
     if ((window as any).Jupyter != null && (window as any).Jupyter.notebook != null) {
-	  // Handle classic Jupyter notebook
+      // Handle classic Jupyter notebook
       const events = (window as any).require('base/js/events')
       events.on('kernel_idle.Kernel', () => this._process_msg())
     } else if ((this.model.widget_manager as any).context != null) {
-	  // Handle JupyterLab
+      // Handle JupyterLab
       (this.model.widget_manager as any).context.sessionContext.statusChanged.connect((_: any, status: any) => {
         if (status === "idle")
           this._process_msg()
       })
+    } else {
+      if (this.model.get("combine_events"))
+		console.warn("BokehView cannot combine events because Kernel idle status cannot be determined.")
+      this._combine = false
     }
     this.listenTo(this.model, "msg:custom", (content, buffers) => this._consume_patch(content, buffers))
   }
@@ -106,23 +148,77 @@ export class BokehView extends DOMWidgetView {
     this._document.on_change((event: any) => this._change_event(event))
   }
 
-  protected _change_event(event: DocumentChangedEvent): void {
-    const {ModelChangedEvent} = bk_require("document/events")
-    if (!this._blocked && event instanceof ModelChangedEvent) {
-      if (!this._idle && this.model.get("combine_events")) {
-        // Queue event and drop previous events on same model attribute
-        const new_msgs = []
-        for (const msg of this._msgs) {
-          if ((msg.id != event.model.id) || (msg.attr != event.attr))
-            new_msgs.push(msg)
-        }
-        new_msgs.push({event: "jsevent", id: event.model.id, new: event.new_, attr: event.attr, old: event.old})
-        this._msgs = new_msgs
-      } else {
-        this._idle = false
-        this.send({event: "jsevent", id: event.model.id, new: event.new_, attr: event.attr, old: event.old})
+  _combine_events(new_msg: any): DocumentChanged[] {
+	const new_msgs = []
+    for (const msg of this._msgs) {
+      if (new_msg.kind != msg.kind)
+		new_msgs.push(msg)
+	  else if (isModelChanged(msg) && isModelChanged(new_msg)) {
+       if (msg.id != new_msg.id || msg.attr != new_msg.attr)
+          new_msgs.push(msg)
+      } else if (isMessageSent(msg) && isMessageSent(new_msg)) {
+        if (
+		  msg.msg_data.event_values.model.id != new_msg.msg_data.event_values.model.id ||
+		  msg.msg_data.event_name != new_msg.msg_data.event_name
+		)
+          new_msgs.push(msg)
       }
     }
+    new_msgs.push(new_msg)
+	return new_msgs
+  }
+
+  _send(msg: DocumentChanged): void {
+	if (!this._idle && this._combine && this.model.get("combine_events"))
+      // Queue event and drop previous events on same model attribute
+      this._msgs = this._combine_events(msg)
+	else {
+      this._idle = false
+      this.send(msg)
+    }
+  }
+
+  protected _change_event(event: DocumentChangedEvent): void {
+    if (this._blocked) { return }
+    const {ModelChangedEvent, MessageSentEvent} = bk_require("document/events")
+    if (event instanceof ModelChangedEvent) {
+      let js_msg: ModelChanged = {
+        event: "jsevent",
+        kind: "ModelChanged",
+        id: event.model.id,
+        attr: event.attr,
+        new: event.new_,
+        old: event.old,
+        hint: null
+	  }
+      if (event.hint != null) {
+        if (event.hint.patches != null) {
+          js_msg["hint"] = {
+            column_source: event.hint.column_source,
+            patches: event.hint.patches
+          }  
+        } else if (event.hint.data != null) {
+          js_msg["hint"] = {
+            column_source: event.hint.column_source,
+            data: event.hint.data,
+            rollover: event.hint.rollover
+          }
+        }
+      }
+	  this._send(js_msg)
+	} else if ((event instanceof MessageSentEvent) && (event.msg_type == "bokeh_event")) {
+	  const msg_data = {...event.msg_data}
+	  const event_values = {...msg_data.event_values}
+	  event_values["model"] = {id: event_values.model.id}
+      msg_data["event_values"] = event_values
+      let js_msg: MessageSent = {
+        event: "jsevent",
+        kind: "MessageSent",
+        msg_type: event.msg_type,
+        msg_data: msg_data
+      }
+	  this._send(js_msg)
+	}
   }
 
   protected _consume_patch(content: {msg: "patch", payload?: Fragment}, buffers: DataView[]): void {

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -116,7 +116,7 @@ export class BokehView extends DOMWidgetView {
       })
     } else {
       if (this.model.get("combine_events"))
-		console.warn("BokehView cannot combine events because Kernel idle status cannot be determined.")
+        console.warn("BokehView cannot combine events because Kernel idle status cannot be determined.")
       this._combine = false
     }
     this.listenTo(this.model, "msg:custom", (content, buffers) => this._consume_patch(content, buffers))
@@ -149,30 +149,30 @@ export class BokehView extends DOMWidgetView {
   }
 
   _combine_events(new_msg: any): DocumentChanged[] {
-	const new_msgs = []
+    const new_msgs = []
     for (const msg of this._msgs) {
       if (new_msg.kind != msg.kind)
-		new_msgs.push(msg)
-	  else if (isModelChanged(msg) && isModelChanged(new_msg)) {
+        new_msgs.push(msg)
+      else if (isModelChanged(msg) && isModelChanged(new_msg)) {
        if (msg.id != new_msg.id || msg.attr != new_msg.attr)
           new_msgs.push(msg)
       } else if (isMessageSent(msg) && isMessageSent(new_msg)) {
         if (
-		  msg.msg_data.event_values.model.id != new_msg.msg_data.event_values.model.id ||
-		  msg.msg_data.event_name != new_msg.msg_data.event_name
-		)
+          msg.msg_data.event_values.model.id != new_msg.msg_data.event_values.model.id ||
+          msg.msg_data.event_name != new_msg.msg_data.event_name
+        )
           new_msgs.push(msg)
       }
     }
     new_msgs.push(new_msg)
-	return new_msgs
+    return new_msgs
   }
 
   _send(msg: DocumentChanged): void {
-	if (!this._idle && this._combine && this.model.get("combine_events"))
+    if (!this._idle && this._combine && this.model.get("combine_events"))
       // Queue event and drop previous events on same model attribute
       this._msgs = this._combine_events(msg)
-	else {
+    else {
       this._idle = false
       this.send(msg)
     }
@@ -190,7 +190,7 @@ export class BokehView extends DOMWidgetView {
         new: event.new_,
         old: event.old,
         hint: null
-	  }
+      }
       if (event.hint != null) {
         if (event.hint.patches != null) {
           js_msg["hint"] = {
@@ -205,11 +205,11 @@ export class BokehView extends DOMWidgetView {
           }
         }
       }
-	  this._send(js_msg)
-	} else if ((event instanceof MessageSentEvent) && (event.msg_type == "bokeh_event")) {
-	  const msg_data = {...event.msg_data}
-	  const event_values = {...msg_data.event_values}
-	  event_values["model"] = {id: event_values.model.id}
+      this._send(js_msg)
+    } else if ((event instanceof MessageSentEvent) && (event.msg_type == "bokeh_event")) {
+      const msg_data = {...event.msg_data}
+      const event_values = {...msg_data.event_values}
+      event_values["model"] = {id: event_values.model.id}
       msg_data["event_values"] = event_values
       let js_msg: MessageSent = {
         event: "jsevent",
@@ -217,8 +217,8 @@ export class BokehView extends DOMWidgetView {
         msg_type: event.msg_type,
         msg_data: msg_data
       }
-	  this._send(js_msg)
-	}
+      this._send(js_msg)
+    }
   }
 
   protected _consume_patch(content: {msg: "patch", payload?: Fragment}, buffers: DataView[]): void {

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -154,7 +154,7 @@ export class BokehView extends DOMWidgetView {
       if (new_msg.kind != msg.kind)
         new_msgs.push(msg)
       else if (isModelChanged(msg) && isModelChanged(new_msg)) {
-       if (msg.id != new_msg.id || msg.attr != new_msg.attr)
+        if (msg.id != new_msg.id || msg.attr != new_msg.attr)
           new_msgs.push(msg)
       } else if (isMessageSent(msg) && isMessageSent(new_msg)) {
         if (
@@ -182,26 +182,26 @@ export class BokehView extends DOMWidgetView {
     if (this._blocked) { return }
     const {ModelChangedEvent, MessageSentEvent} = bk_require("document/events")
     if (event instanceof ModelChangedEvent) {
-      let js_msg: ModelChanged = {
+      const js_msg: ModelChanged = {
         event: "jsevent",
         kind: "ModelChanged",
         id: event.model.id,
         attr: event.attr,
         new: event.new_,
         old: event.old,
-        hint: null
+        hint: null,
       }
       if (event.hint != null) {
         if (event.hint.patches != null) {
           js_msg["hint"] = {
             column_source: event.hint.column_source,
-            patches: event.hint.patches
-          }  
+            patches: event.hint.patches,
+          }
         } else if (event.hint.data != null) {
           js_msg["hint"] = {
             column_source: event.hint.column_source,
             data: event.hint.data,
-            rollover: event.hint.rollover
+            rollover: event.hint.rollover,
           }
         }
       }
@@ -211,11 +211,11 @@ export class BokehView extends DOMWidgetView {
       const event_values = {...msg_data.event_values}
       event_values["model"] = {id: event_values.model.id}
       msg_data["event_values"] = event_values
-      let js_msg: MessageSent = {
+      const js_msg: MessageSent = {
         event: "jsevent",
         kind: "MessageSent",
         msg_type: event.msg_type,
-        msg_data: msg_data
+        msg_data: msg_data,
       }
       this._send(js_msg)
     }

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -30,7 +30,7 @@ export type RenderBundle = {
 export class BokehModel extends DOMWidgetModel {
   defaults() {
     return {
-      ...super.defaults(),
+      ...super.defaults(),  
 
       _model_name: "BokehModel",
       _model_module: name,
@@ -40,6 +40,7 @@ export class BokehModel extends DOMWidgetModel {
       _view_module: name,
       _view_module_version: version_range,
 
+      combine_events: false,
       render_bundle: {},
     }
   }
@@ -53,15 +54,36 @@ export class BokehView extends DOMWidgetView {
   private _document: Document | null
   private _receiver: Receiver
   private _blocked: boolean
+  private _msgs: any[]
+  private _idle: boolean
 
   constructor(options?: any) {
     super(options)
     this._document = null
     this._blocked = false
+    this._idle = true
+    this._msgs = []
     const {Receiver} = bk_require("protocol/receiver")
     this._receiver = new Receiver()
     this.model.on("change:render_bundle", () => this.render())
+    if ((window as any).Jupyter != null) {
+      const events = (window as any).require('base/js/events')
+      events.on('kernel_idle.Kernel', () => this._process_msg())
+    } else {
+      (this.model.widget_manager as any).context.sessionContext.statusChanged.connect((_: any, status: any) => {
+        if (status === "idle")
+          this._process_msg()
+      })
+    }
     this.listenTo(this.model, "msg:custom", (content, buffers) => this._consume_patch(content, buffers))
+  }
+
+  protected _process_msg(): void {
+    if (this._msgs.length == 0) {
+      this._idle = true
+      return
+    }
+    this.send(this._msgs.shift())
   }
 
   render(): void {
@@ -84,8 +106,20 @@ export class BokehView extends DOMWidgetView {
 
   protected _change_event(event: DocumentChangedEvent): void {
     const {ModelChangedEvent} = bk_require("document/events")
-    if (!this._blocked && event instanceof ModelChangedEvent)
-      this.send({event: "jsevent", id: event.model.id, new: event.new_, attr: event.attr, old: event.old})
+    if (!this._blocked && event instanceof ModelChangedEvent) {
+      if (!this._idle && this.model.get("combine_events")) {
+        const new_msgs = []
+        for (const msg of this._msgs) {
+          if ((msg.id != event.model.id) || (msg.attr != event.attr))
+            new_msgs.push(msg)
+        }
+        new_msgs.push({event: "jsevent", id: event.model.id, new: event.new_, attr: event.attr, old: event.old})
+        this._msgs = new_msgs
+      } else {
+        this._idle = false
+        this.send({event: "jsevent", id: event.model.id, new: event.new_, attr: event.attr, old: event.old})
+      }
+    }
   }
 
   protected _consume_patch(content: {msg: "patch", payload?: Fragment}, buffers: DataView[]): void {

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -30,7 +30,7 @@ export type RenderBundle = {
 export class BokehModel extends DOMWidgetModel {
   defaults() {
     return {
-      ...super.defaults(),  
+      ...super.defaults(),
 
       _model_name: "BokehModel",
       _model_module: name,
@@ -110,7 +110,7 @@ export class BokehView extends DOMWidgetView {
     const {ModelChangedEvent} = bk_require("document/events")
     if (!this._blocked && event instanceof ModelChangedEvent) {
       if (!this._idle && this.model.get("combine_events")) {
-		// Queue event and drop previous events on same model attribute
+        // Queue event and drop previous events on same model attribute
         const new_msgs = []
         for (const msg of this._msgs) {
           if ((msg.id != event.model.id) || (msg.attr != event.attr))


### PR DESCRIPTION
This queues events if the `combine_events` option is enabled and combines events on the same property if the previous event has not finished processing.

The basic approach here is:

1. Attach listener to register kernel status `idle` events
2. If there are no events queued send event and set `_idle = false`
4. If another event is triggered while `!idle` then queue event but drop any previous events on the same model attribute
4. When event finishes kernel status idle event is triggered process the next item in the queue
5. Repeat until there are no more events in the queue, then set `_idle = true`
