### PR TITLE
Update installation details

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jupyter labextension install @bokeh/jupyter_bokeh@x.y.x
 
 ## Compatibility
 
-The core [Bokeh](https://github.com/bokeh/bokeh) library is generally version ndependent of
+The core [Bokeh](https://github.com/bokeh/bokeh) library is generally version independent of
 [JupyterLab](https://github.com/jupyterlab/jupyterlab) and this ``jupyter_bokeh`` extension
 for versions of ``bokeh>=2.0.0``.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A Jupyter extension for rendering [Bokeh](https://bokeh.org) content within Jupy
 
 ## Install
 
-To install the latest version in Jupyter Lab:
+For versions 3.0 and newer of JupyterLab, you have the option to install
+jupyter_bokeh with either ``pip`` or ``conda``:
 
 ```bash
 pip install jupyter_bokeh
@@ -15,11 +16,11 @@ pip install jupyter_bokeh
 
 or
 
-```
+```bash
 conda install -c bokeh jupyter_bokeh
 ```
 
-For versions of Jupyter Lab <3.0 you must install the labextension
+For versions of Jupyter Lab older than 3.0, you must install the labextension
 separately:
 
 ```bash
@@ -36,12 +37,12 @@ jupyter labextension install @bokeh/jupyter_bokeh@x.y.x
 
 ## Compatibility
 
-The core [Bokeh](https://github.com/bokeh/bokeh) library is generally version independent of
+The core [Bokeh](https://github.com/bokeh/bokeh) library is generally version ndependent of
 [JupyterLab](https://github.com/jupyterlab/jupyterlab) and this ``jupyter_bokeh`` extension
 for versions of ``bokeh>=2.0.0``.
 
 Our goal is that ``jupyter_bokeh`` minor releases (using the [SemVer](https://semver.org/) pattern) are
-made to follow JupyterLab minor release bumps and micro releases are for new ``jupyter_bokeh`` features
+made to follow JupyterLab minor release bumps, while micro releases are for new ``jupyter_bokeh`` features
 or bug fix releases. We've been previously inconsistent with having the extension release minor version bumps
 track that of JupyterLab, so users seeking to find extension releases that are compatible with their JupyterLab
 installation may refer to the below table.


### PR DESCRIPTION
Following #125 and https://github.com/bokeh/bokeh/issues/11097, this PR updates some details of the installation instructions (versions 3.0 and younger vs. older versions).