### PR TITLE
fix license name

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE
+include LICENSE.txt
 include README.md
 include pyproject.toml
 include jupyter-config/jupyter_bokeh.json


### PR DESCRIPTION
- restores `LICENSE(.txt)`
- noticed on https://github.com/conda-forge/jupyter_bokeh-feedstock/pull/5