### PR TITLE
Update jupyter_widgets.ipynb to reflect correct import

### DIFF
--- a/examples/jupyter_widgets.ipynb
+++ b/examples/jupyter_widgets.ipynb
@@ -11,6 +11,7 @@
     "from bokeh.io import output_notebook\n",
     "import bokeh.models.widgets as bk\n",
     "import jupyter_bokeh as jbk\n",
+    "import jupyter_bokeh.widgets as jbkw\n",
     "import ipywidgets as ip"
    ]
   },
@@ -62,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "jbk.BokehModel(p)"
+    "jbkw.BokehModel(p)"
    ]
   },
   {


### PR DESCRIPTION
Update jupyter_widgets.ipynb (since it serves as documentation) to reflect correct import to instantiate BokehModel (`jupyter_bokeh.widgets` instead of just `jupyter_bokeh`)