### PR TITLE
restoring BokehModel import in __init__.py (reverts part of 8f21a15)

### DIFF
--- a/jupyter_bokeh/__init__.py
+++ b/jupyter_bokeh/__init__.py
@@ -6,6 +6,7 @@ from ._version import __version__
 
 HERE = Path(__file__).parent.resolve()
 
+from .widgets import BokehModel
 with (HERE / "labextension" / "package.json").open() as fid:
     data = json.load(fid)
 


### PR DESCRIPTION
Related to issue https://github.com/bokeh/jupyter_bokeh/issues/137 