### PR TITLE
Add NODE_OPTIONS to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 jupyter_bokeh setup
 """
 import json
+import os
 from pathlib import Path
 
 from jupyter_packaging import (
@@ -12,6 +13,10 @@ from jupyter_packaging import (
     skip_if_exists
 )
 import setuptools
+
+# For working with NodeJS >= 17
+# See: https://stackoverflow.com/questions/69394632
+os.environ["NODE_OPTIONS"] = "--openssl-legacy-provider"
 
 HERE = Path(__file__).parent.resolve()
 


### PR DESCRIPTION
I tried installing this locally but got the following error. This is because I have installed Node v18.12.1 installed. Adding the environment variables should be seen as a temporary workaround and was found [here](https://stackoverflow.com/questions/69394632/webpack-build-failing-with-err-ossl-evp-unsupported). 

This can be closed if a fix is available. 


<details>
  <summary>Traceback </summary>


``` python
❯ python -m pip install "git+https://github.com/bokeh/jupyter_bokeh.git"
Collecting git+https://github.com/bokeh/jupyter_bokeh.git
  Cloning https://github.com/bokeh/jupyter_bokeh.git to /tmp/pip-req-build-9fmavl8j
  Running command git clone --filter=blob:none --quiet https://github.com/bokeh/jupyter_bokeh.git /tmp/pip-req-build-9fmavl8j
  Resolved https://github.com/bokeh/jupyter_bokeh.git to commit f343b904b2d6f95b62537abb6b0e763bafb617b3
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting ipywidgets>=7.6.0
  Using cached ipywidgets-8.0.4-py3-none-any.whl (137 kB)
Collecting bokeh>=2.4.0
  Using cached bokeh-3.0.3-py3-none-any.whl (16.5 MB)
Collecting pillow>=7.1.0
  Using cached Pillow-9.4.0-cp310-cp310-manylinux_2_28_x86_64.whl (3.4 MB)
Collecting xyzservices>=2021.09.1
  Using cached xyzservices-2023.2.0-py3-none-any.whl (55 kB)
Collecting contourpy>=1
  Using cached contourpy-1.0.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (300 kB)
Requirement already satisfied: Jinja2>=2.9 in /home/shh/.local/lib/python3.10/site-packages (from bokeh>=2.4.0->jupyter-bokeh==3.0.4) (3.1.2)
Collecting PyYAML>=3.10
  Using cached PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (682 kB)
Requirement already satisfied: pandas>=1.2 in /home/shh/.local/lib/python3.10/site-packages (from bokeh>=2.4.0->jupyter-bokeh==3.0.4) (1.5.2)
Requirement already satisfied: tornado>=5.1 in /home/shh/.local/lib/python3.10/site-packages (from bokeh>=2.4.0->jupyter-bokeh==3.0.4) (6.2)
Requirement already satisfied: packaging>=16.8 in /home/shh/.local/lib/python3.10/site-packages (from bokeh>=2.4.0->jupyter-bokeh==3.0.4) (22.0)
Collecting numpy>=1.11.3
  Using cached numpy-1.24.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.3 MB)
Collecting widgetsnbextension~=4.0
  Using cached widgetsnbextension-4.0.5-py3-none-any.whl (2.0 MB)
Collecting ipykernel>=4.5.1
  Using cached ipykernel-6.21.2-py3-none-any.whl (149 kB)
Collecting ipython>=6.1.0
  Using cached ipython-8.10.0-py3-none-any.whl (784 kB)
Collecting traitlets>=4.3.1
  Using cached traitlets-5.9.0-py3-none-any.whl (117 kB)
Collecting jupyterlab-widgets~=3.0
  Using cached jupyterlab_widgets-3.0.5-py3-none-any.whl (384 kB)
Collecting jupyter-core!=5.0.*,>=4.12
  Using cached jupyter_core-5.2.0-py3-none-any.whl (94 kB)
Collecting debugpy>=1.6.5
  Using cached debugpy-1.6.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.0 MB)
Collecting jupyter-client>=6.1.12
  Using cached jupyter_client-8.0.3-py3-none-any.whl (102 kB)
Collecting matplotlib-inline>=0.1
  Using cached matplotlib_inline-0.1.6-py3-none-any.whl (9.4 kB)
Collecting nest-asyncio
  Using cached nest_asyncio-1.5.6-py3-none-any.whl (5.2 kB)
Collecting comm>=0.1.1
  Using cached comm-0.1.2-py3-none-any.whl (6.5 kB)
Collecting pyzmq>=20
  Using cached pyzmq-25.0.0-cp310-cp310-manylinux_2_28_x86_64.whl (1.1 MB)
Collecting psutil
  Using cached psutil-5.9.4-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (280 kB)
Collecting pickleshare
  Using cached pickleshare-0.7.5-py2.py3-none-any.whl (6.9 kB)
Collecting pygments>=2.4.0
  Using cached Pygments-2.14.0-py3-none-any.whl (1.1 MB)
Collecting pexpect>4.3
  Using cached pexpect-4.8.0-py2.py3-none-any.whl (59 kB)
Collecting backcall
  Using cached backcall-0.2.0-py2.py3-none-any.whl (11 kB)
Collecting prompt-toolkit<3.1.0,>=3.0.30
  Using cached prompt_toolkit-3.0.36-py3-none-any.whl (386 kB)
Collecting jedi>=0.16
  Using cached jedi-0.18.2-py2.py3-none-any.whl (1.6 MB)
Collecting stack-data
  Using cached stack_data-0.6.2-py3-none-any.whl (24 kB)
Collecting decorator
  Using cached decorator-5.1.1-py3-none-any.whl (9.1 kB)
Collecting MarkupSafe>=2.0
  Using cached MarkupSafe-2.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (25 kB)
Requirement already satisfied: python-dateutil>=2.8.1 in /home/shh/.local/lib/python3.10/site-packages (from pandas>=1.2->bokeh>=2.4.0->jupyter-bokeh==3.0.4) (2.8.2)
Collecting pytz>=2020.1
  Using cached pytz-2022.7.1-py2.py3-none-any.whl (499 kB)
Collecting parso<0.9.0,>=0.8.0
  Using cached parso-0.8.3-py2.py3-none-any.whl (100 kB)
Collecting platformdirs>=2.5
  Using cached platformdirs-3.0.0-py3-none-any.whl (14 kB)
Collecting ptyprocess>=0.5
  Using cached ptyprocess-0.7.0-py2.py3-none-any.whl (13 kB)
Collecting wcwidth
  Using cached wcwidth-0.2.6-py2.py3-none-any.whl (29 kB)
Collecting six>=1.5
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting asttokens>=2.1.0
  Using cached asttokens-2.2.1-py2.py3-none-any.whl (26 kB)
Collecting pure-eval
  Using cached pure_eval-0.2.2-py3-none-any.whl (11 kB)
Collecting executing>=1.2.0
  Using cached executing-1.2.0-py2.py3-none-any.whl (24 kB)
Building wheels for collected packages: jupyter-bokeh
  Building wheel for jupyter-bokeh (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for jupyter-bokeh (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [104 lines of output]
      /tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/setuptools/config/setupcfg.py:520: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
        warnings.warn(msg, warning_class)
      running bdist_wheel
      running jsdeps
      Installing build dependencies with npm.  This may take a while...
      > jlpm install
      yarn install v1.21.1
      warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
      [1/4] Resolving packages...
      [2/4] Fetching packages...
      info fsevents@2.3.2: The platform "linux" is incompatible with this module.
      info "fsevents@2.3.2" is an optional dependency and failed compatibility check. Excluding it from installation.
      info fsevents@1.2.13: The platform "linux" is incompatible with this module.
      info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
      [3/4] Linking dependencies...
      warning "@jupyter-widgets/base > @lumino/coreutils@1.8.0" has unmet peer dependency "crypto@1.0.1".
      warning "@jupyterlab/application > @jupyterlab/ui-components@3.0.7" has unmet peer dependency "react@^17.0.1".
      [4/4] Building fresh packages...
      $ jlpm run clean && jlpm run build:prod
      yarn run v1.21.1
      $ jlpm run clean:lib
      $ rimraf lib tsconfig.tsbuildinfo
      Done in 0.55s.
      yarn run v1.21.1
      $ jlpm run build:lib && jlpm run build:nbextension && jlpm run build:labextension
      $ tsc
      $ webpack -p
      node:internal/crypto/hash:71
        this[kHandle] = new _Hash(algorithm, xofLen);
                        ^
      
      Error: error:0308010C:digital envelope routines::unsupported
          at new Hash (node:internal/crypto/hash:71:19)
          at Object.createHash (node:crypto:133:10)
          at module.exports (/tmp/pip-req-build-9fmavl8j/node_modules/webpack/lib/util/createHash.js:135:53)
          at NormalModule._initBuildHash (/tmp/pip-req-build-9fmavl8j/node_modules/webpack/lib/NormalModule.js:417:16)
          at handleParseError (/tmp/pip-req-build-9fmavl8j/node_modules/webpack/lib/NormalModule.js:471:10)
          at /tmp/pip-req-build-9fmavl8j/node_modules/webpack/lib/NormalModule.js:503:5
          at /tmp/pip-req-build-9fmavl8j/node_modules/webpack/lib/NormalModule.js:358:12
          at /tmp/pip-req-build-9fmavl8j/node_modules/loader-runner/lib/LoaderRunner.js:373:3
          at iterateNormalLoaders (/tmp/pip-req-build-9fmavl8j/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
          at Array.<anonymous> (/tmp/pip-req-build-9fmavl8j/node_modules/loader-runner/lib/LoaderRunner.js:205:4)
          at Storage.finished (/tmp/pip-req-build-9fmavl8j/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:55:16)
          at /tmp/pip-req-build-9fmavl8j/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:91:9
          at /tmp/pip-req-build-9fmavl8j/node_modules/graceful-fs/graceful-fs.js:123:16
          at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read_file_context:68:3) {
        opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
        library: 'digital envelope routines',
        reason: 'unsupported',
        code: 'ERR_OSSL_EVP_UNSUPPORTED'
      }
      
      Node.js v18.12.1
      error Command failed with exit code 1.
      info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
      error Command failed with exit code 1.
      info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
      error Command failed with exit code 1.
      info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
      Traceback (most recent call last):
        File "/home/shh/miniconda3/envs/tmp4/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/shh/miniconda3/envs/tmp4/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/shh/miniconda3/envs/tmp4/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 251, in build_wheel
          return _build_backend().build_wheel(wheel_directory, config_settings,
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 413, in build_wheel
          return self._build_with_temp_dir(['bdist_wheel'], '.whl',
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 398, in _build_with_temp_dir
          self.run_setup()
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 335, in run_setup
          exec(code, locals())
        File "<string>", line 99, in <module>
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/setuptools/__init__.py", line 108, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 185, in setup
          return run_commands(dist)
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/setuptools/dist.py", line 1221, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/jupyter_packaging/setupbase.py", line 503, in run
          [self.run_command(cmd) for cmd in cmds]
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/jupyter_packaging/setupbase.py", line 503, in <listcomp>
          [self.run_command(cmd) for cmd in cmds]
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/setuptools/_distutils/cmd.py", line 318, in run_command
          self.distribution.run_command(command)
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/setuptools/dist.py", line 1221, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/jupyter_packaging/setupbase.py", line 274, in run
          c.run()
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/jupyter_packaging/setupbase.py", line 379, in run
          run(npm_cmd + ['install'], cwd=node_package)
        File "/tmp/pip-build-env-btgz651o/overlay/lib/python3.10/site-packages/jupyter_packaging/setupbase.py", line 225, in run
          return subprocess.check_call(cmd, **kwargs)
        File "/home/shh/miniconda3/envs/tmp4/lib/python3.10/subprocess.py", line 369, in check_call
          raise CalledProcessError(retcode, cmd)
      subprocess.CalledProcessError: Command '['/tmp/pip-build-env-btgz651o/overlay/bin/jlpm', 'install']' returned non-zero exit status 1.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for jupyter-bokeh
Failed to build jupyter-bokeh
ERROR: Could not build wheels for jupyter-bokeh, which is required to install pyproject.toml-based projects

```

</details>