### PR TITLE
Fix handling of Columns<> events

### DIFF
--- a/jupyter_bokeh/widgets.py
+++ b/jupyter_bokeh/widgets.py
@@ -151,15 +151,15 @@ class BokehModel(DOMWidget):
             for cb in model._callbacks.get(attr, []):
                 cb(attr, old, new)
         elif kind == "ColumnsStreamed":
-            model = content["model"]
-            data = content["data"]
-            rollover = content["rollover"]
+            model = event["model"]
+            data = event["data"]
+            rollover = event["rollover"]
 
             assert isinstance(model, ColumnDataSource)
             model._stream(data, rollover, setter=setter)
         elif kind == "ColumnsPatched":
-            model = content["model"]
-            patches = content["data"]
+            model = event["model"]
+            patches = event["patches"]
 
             assert isinstance(model, ColumnDataSource)
             model.patch(patches, setter=setter)


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/5513

I've so far only been able to "test" this change for `ColumnsPatched`, not form `ColumnsStreamed`, but I'd be happy to also "test" it if someone can indicate how to trigger it.

---

This example used to fail when updating the table in a notebook. Note it wraps the model with `BokehModel` from `jupyter_bokeh` (as discussed in https://github.com/bokeh/jupyter_bokeh/issues/199) to reproduce the issue with Bokeh code only, avoiding Panel.

```python
from IPython.display import display
from jupyter_bokeh.widgets import BokehModel
from bokeh.io import output_notebook
from bokeh.models import ColumnDataSource, DataTable, TableColumn

output_notebook()

source = ColumnDataSource(dict(values=[0, 1, 2, 3, 4]))
columns = [TableColumn(field="values")]
data_table = DataTable(source=source, columns=columns, editable=True, height=150)

display(BokehModel(data_table))
```

The traceback that was raised in that case:

```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
File /private/tmp/issue_key/.venv/lib/python3.12/site-packages/jupyter_bokeh/widgets.py:162, in BokehModel._sync_model(self, _model, content, _buffers)
    [160](https://file+.vscode-resource.vscode-cdn.net/private/tmp/issue_key/.venv/lib/python3.12/site-packages/jupyter_bokeh/widgets.py:160) elif kind == "ColumnsPatched":
    [161](https://file+.vscode-resource.vscode-cdn.net/private/tmp/issue_key/.venv/lib/python3.12/site-packages/jupyter_bokeh/widgets.py:161)     model = content["model"]
--> [162](https://file+.vscode-resource.vscode-cdn.net/private/tmp/issue_key/.venv/lib/python3.12/site-packages/jupyter_bokeh/widgets.py:162)     patches = content["data"]
    [164](https://file+.vscode-resource.vscode-cdn.net/private/tmp/issue_key/.venv/lib/python3.12/site-packages/jupyter_bokeh/widgets.py:164)     assert isinstance(model, ColumnDataSource)
    [165](https://file+.vscode-resource.vscode-cdn.net/private/tmp/issue_key/.venv/lib/python3.12/site-packages/jupyter_bokeh/widgets.py:165)     model.patch(patches, setter=setter)

KeyError: 'data'
```

With the changes applied, it seems to work well:

![jupyter_bokeh2](https://github.com/bokeh/jupyter_bokeh/assets/35924738/f1b8474e-54dd-46f4-b8b1-a5f782c9167e)
