### PR TITLE
Fix nbextension packaging and allow inline resources in VSCode.

### DIFF
--- a/jupyter_bokeh/__init__.py
+++ b/jupyter_bokeh/__init__.py
@@ -19,7 +19,7 @@ def _jupyter_labextension_paths():
 def _jupyter_nbextension_paths():
     return [{
         "section": "notebook",
-        "src": "nbextension/static",
+        "src": "nbextension",
         "dest": "jupyter_bokeh",
         "require": "jupyter_bokeh/extension",
     }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,15 +49,16 @@ source = "nodejs"
 fields = ["description", "authors", "urls"]
 
 [tool.hatch.build.targets.sdist]
-artifacts = ["jupyter_bokeh/labextension"]
+artifacts = ["jupyter_bokeh/labextension", "jupyter_bokeh/nbextension"]
 exclude = [".github", "binder"]
 
 [tool.hatch.build.targets.wheel]
-artifacts = ["jupyter_bokeh/labextension"]
+artifacts = ["jupyter_bokeh/labextension", "jupyter_bokeh/nbextension"]
 
 [tool.hatch.build.targets.wheel.shared-data]
 "jupyter_bokeh/labextension" = "share/jupyter/labextensions/@bokeh/jupyter_bokeh"
 "install.json" = "share/jupyter/labextensions/@bokeh/jupyter_bokeh/install.json"
+"jupyter_bokeh/nbextension" = "share/jupyter/nbextensions/jupyter_bokeh"
 
 [tool.hatch.build.hooks.version]
 path = "jupyter_bokeh/_version.py"
@@ -68,6 +69,7 @@ build-function = "hatch_jupyter_builder.npm_builder"
 ensured-targets = [
     "jupyter_bokeh/labextension/static/style.js",
     "jupyter_bokeh/labextension/package.json",
+    "jupyter_bokeh/nbextension/index.js",
 ]
 skip-if-exists = ["jupyter_bokeh/labextension/static/style.js"]
 


### PR DESCRIPTION
This makes it possible to use this ipywidget in Visual Studio Code without having to download resources from a CDN.
The packaged files existed but the packaging broke due to two refactoring commits in the past.

- 2021 (81f4b00): changed nbextension/static to nbextension but forgot to update `_jupyter_nbextension_paths()`.
- 2024 (9e94b21): migration from setuptools to hatchling dropped the nbextension from artifacts and `index.js` stopped being included in the wheel because it is gitignored.